### PR TITLE
Switch frontend/backend integration to GoldAPI service

### DIFF
--- a/README_FIX.txt
+++ b/README_FIX.txt
@@ -1,21 +1,32 @@
 FIX: Netlify secrets scanning
 
+## Actualización 2024: backend Express con GoldAPI
+
+- Configura en Render (o el host donde corra `server/index.js`) las variables:
+  - `GOLDAPI_KEY`, `GOLDAPI_BASE`, `SYMBOL`, `CSV_PATH`, `PORT` (opcional `GOLDAPI_TIMEOUT_MS`).
+- El frontend ahora llama a `/api/spot`, `/api/historical` y `/api/update-csv`.
+  - En Netlify (scope Builds) define `VITE_BACKEND_BASE` si el backend vive en otro dominio.
+- Las claves ya **no se exponen** en el bundle del cliente; quedan en el backend.
+
+Las notas originales del escaneo de secretos se mantienen debajo por si sigues usando
+Netlify Functions heredadas.
+
 1) Elimina cualquier archivo que establezca claves en el frontend:
    - BORRA si existen: /config.js (raíz) y /public/config.js
      (Si prefieres mantener /public/config.js, usa exactamente el que viene en este paquete; está vacío.)
 
 2) Sustituye /index.html por el incluido (no carga config.js ni scripts con claves).
 
-3) Asegúrate de que el frontend NO utiliza import.meta.env.VITE_METALS_API_KEY ni VITE_API_BASE.
+3) [LEGADO] Asegúrate de que el frontend NO utiliza import.meta.env.VITE_METALS_API_KEY ni VITE_API_BASE.
    En su lugar, llama a /.netlify/functions/metalprices (clave en Functions).
 
-4) Si el escaneo sigue señalando el CSV grande de /public/data, añade en Netlify (scope Builds):
+4) [LEGADO] Si el escaneo sigue señalando el CSV grande de /public/data, añade en Netlify (scope Builds):
      SECRETS_SCAN_OMIT_PATHS=public/data
    Esto SOLO omite el escaneo del CSV, no de otros archivos.
 
-5) Redeploy: Clear cache and deploy site.
+5) [LEGADO] Redeploy: Clear cache and deploy site.
 
-Nota: Si necesitas, vuelve a importar en Functions:
+Nota: [LEGADO] Si necesitas, vuelve a importar en Functions:
   API_BASE=https://TU_API_DE_METALPRICES/v1
   METALS_API_KEY=TU_CLAVE
   (y las vars de GitHub si usas update-csv)

--- a/env.builds
+++ b/env.builds
@@ -2,12 +2,12 @@
 # Scope al importar en Netlify: Builds
 # Deploy contexts: All
 
-# --- Config de tu API de MetalPrices ---
-# Cambia esta URL por la base real de tu proveedor
-VITE_API_BASE=https://TU_API_DE_METALPRICES/v1
-VITE_METALS_API_KEY=PEGA_AQUI_TU_API_KEY
+# --- Config del backend Express ---
+# Si el frontend (Netlify) habla con Render, pon aquí la URL base
+# (por ejemplo https://klevergold-backend.onrender.com). Deja vacío
+# para que use el mismo origen.
+VITE_BACKEND_BASE=
 
 # --- Ajustes del dashboard ---
 VITE_SYMBOL=XAUUSD
 VITE_CSV_URL=/data/xauusd_ohlc_clean.csv
-VITE_REQUEST_DELAY_MS=1100

--- a/server/index.js
+++ b/server/index.js
@@ -7,10 +7,100 @@ import path from 'path';
 
 // Configuración por variables de entorno
 const PORT = process.env.PORT || 8080;
-const GOLDAPI_KEY  = process.env.GOLDAPI_KEY  || ''; // por ejemplo goldapi-goo8sm5s2xwpc-io
-const GOLDAPI_BASE = process.env.GOLDAPI_BASE || 'https://www.goldapi.io/api';
-const SYMBOL       = process.env.SYMBOL       || 'XAUUSD'; // par metal-divisa por defecto
-const CSV_PATH     = process.env.CSV_PATH     || path.join('public', 'data', 'xauusd_ohlc_clean.csv');
+const GOLDAPI_KEY = process.env.GOLDAPI_KEY || '';
+const GOLDAPI_BASE = (process.env.GOLDAPI_BASE || 'https://www.goldapi.io/api').replace(/\/$/, '');
+const SYMBOL_RAW = process.env.SYMBOL || 'XAUUSD';
+const DEFAULT_CSV_PATH = path.resolve(process.cwd(), 'public', 'data', 'xauusd_ohlc_clean.csv');
+const CSV_PATH = process.env.CSV_PATH ? path.resolve(process.env.CSV_PATH) : DEFAULT_CSV_PATH;
+
+function parseSymbolPair(input = 'XAUUSD') {
+  const str = String(input || '').toUpperCase();
+  // Admite variantes como XAU/USD, XAU-USD o simplemente XAUUSD
+  const compact = str.replace(/[^A-Z]/g, '');
+  if (compact.length >= 6) {
+    const currency = compact.slice(-3);
+    const metal = compact.slice(0, compact.length - 3);
+    return {
+      pair: `${metal}${currency}`,
+      metal,
+      currency,
+    };
+  }
+  return { pair: 'XAUUSD', metal: 'XAU', currency: 'USD' };
+}
+
+const SYMBOL_INFO = parseSymbolPair(SYMBOL_RAW);
+
+const HTTP_TIMEOUT_MS = Number(process.env.GOLDAPI_TIMEOUT_MS || 15_000);
+
+const axiosConfig = {
+  baseURL: GOLDAPI_BASE,
+  timeout: HTTP_TIMEOUT_MS,
+  headers: {
+    'x-access-token': GOLDAPI_KEY,
+    Accept: 'application/json',
+  },
+};
+
+const goldApiClient = axios.create(axiosConfig);
+
+const iso = (d) => new Date(d).toISOString().slice(0, 10);
+const toNumber = (value, fallback = NaN) => {
+  if (value === null || value === undefined || value === '') return fallback;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : fallback;
+};
+
+function normalizeOhlc(row, defaults = {}) {
+  const date = String(row?.date || defaults.date || '').slice(0, 10);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) return null;
+  const openRaw = toNumber(row?.open, defaults.open);
+  const closeRaw = toNumber(row?.close, defaults.close);
+  const highRaw = toNumber(row?.high, defaults.high);
+  const lowRaw = toNumber(row?.low, defaults.low);
+
+  if (!Number.isFinite(openRaw) || !Number.isFinite(closeRaw)) return null;
+
+  const highCandidates = [highRaw, openRaw, closeRaw].filter(Number.isFinite);
+  const lowCandidates = [lowRaw, openRaw, closeRaw].filter(Number.isFinite);
+  const high = highCandidates.length ? Math.max(...highCandidates) : Math.max(openRaw, closeRaw);
+  const low = lowCandidates.length ? Math.min(...lowCandidates) : Math.min(openRaw, closeRaw);
+
+  return {
+    date,
+    open: openRaw,
+    high,
+    low,
+    close: closeRaw,
+    symbol: row?.symbol || defaults.symbol || SYMBOL_INFO.pair,
+  };
+}
+
+function readCsvAsMap(csvPath) {
+  const map = new Map();
+  if (!fs.existsSync(csvPath)) return map;
+  const content = fs.readFileSync(csvPath, 'utf-8');
+  if (!content.trim()) return map;
+  const lines = content.trim().split(/\r?\n/);
+  const startIdx = lines[0]?.toLowerCase().startsWith('date') ? 1 : 0;
+  for (let i = startIdx; i < lines.length; i += 1) {
+    const [date, symbol, open, high, low, close] = lines[i].split(',');
+    const normalized = normalizeOhlc({ date, symbol, open, high, low, close });
+    if (normalized) {
+      map.set(normalized.date, normalized);
+    }
+  }
+  return map;
+}
+
+function writeMapToCsv(map, csvPath) {
+  const header = 'date,symbol,open,high,low,close';
+  const rows = Array.from(map.values()).sort((a, b) => a.date.localeCompare(b.date));
+  const out = [header, ...rows.map((r) => `${r.date},${r.symbol || SYMBOL_INFO.pair},${r.open},${r.high},${r.low},${r.close}`)].join('\n');
+  fs.mkdirSync(path.dirname(csvPath), { recursive: true });
+  fs.writeFileSync(csvPath, `${out}\n`, 'utf-8');
+  return rows;
+}
 
 const app = express();
 app.use(cors());
@@ -26,17 +116,17 @@ app.get('/api/spot', async (req, res) => {
     return res.status(500).json({ ok: false, error: 'Falta GOLDAPI_KEY' });
   }
   try {
-    const url = `${GOLDAPI_BASE}/${SYMBOL.slice(0, -3)}/${SYMBOL.slice(-3)}`;
-    const r = await axios.get(url, {
-      headers: { 'x-access-token': GOLDAPI_KEY },
-    });
-    const data = r.data;
-    const price = Number(data.price);
-    const ts    = data.timestamp ? Number(data.timestamp) * 1000 : Date.now();
-    if (!Number.isFinite(price)) throw new Error('Precio no válido');
+    const response = await goldApiClient.get(`/${SYMBOL_INFO.metal}/${SYMBOL_INFO.currency}`);
+    const data = response.data || {};
+    if (data?.error) throw new Error(data.error);
+    const price = toNumber(data.price);
+    if (!Number.isFinite(price) || price <= 0) throw new Error('Precio no válido');
+    const tsSec = toNumber(data.timestamp);
+    const ts = Number.isFinite(tsSec) ? tsSec * 1000 : Date.now();
     res.json({ ok: true, price, ts });
-  } catch (e) {
-    res.status(502).json({ ok: false, error: 'No se pudo obtener el spot', detail: e.message });
+  } catch (error) {
+    const detail = error?.response?.data?.error || error?.message || 'Error desconocido';
+    res.status(502).json({ ok: false, error: 'No se pudo obtener el spot', detail });
   }
 });
 
@@ -50,49 +140,65 @@ app.get('/api/historical', async (req, res) => {
     return res.status(500).json({ ok: false, error: 'Falta GOLDAPI_KEY' });
   }
   let { from, to } = req.query;
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = iso(new Date());
   const dateRegex = /^\d{4}-\d{2}-\d{2}$/;
 
-  // Validación básica y ajuste de fechas
-  if (!dateRegex.test(from) || !dateRegex.test(to)) {
+  if (!dateRegex.test(from || '') || !dateRegex.test(to || '')) {
     const d = new Date();
     d.setUTCDate(d.getUTCDate() - 1);
-    from = to = d.toISOString().slice(0,10);
+    from = to = iso(d);
   }
+
   if (to >= todayIso) {
     const d = new Date();
     d.setUTCDate(d.getUTCDate() - 1);
-    to = d.toISOString().slice(0,10);
+    to = iso(d);
   }
+
   if (from > to) from = to;
 
-  // Iterar día a día
   try {
     const start = new Date(`${from}T00:00:00Z`);
-    const end   = new Date(`${to}T00:00:00Z`);
+    const end = new Date(`${to}T00:00:00Z`);
     const rows = [];
-    for (let d = start; d <= end; d.setUTCDate(d.getUTCDate() + 1)) {
-      const yyyymmdd = d.toISOString().slice(0,10).replace(/-/g,'');
-      const url = `${GOLDAPI_BASE}/${SYMBOL.slice(0, -3)}/${SYMBOL.slice(-3)}/${yyyymmdd}`;
-      const r = await axios.get(url, {
-        headers: { 'x-access-token': GOLDAPI_KEY },
-      });
-      const j = r.data;
-      if (j && Number.isFinite(j.price)) {
-        const { open_price, high_price, low_price, price } = j;
-        rows.push({
-          date: d.toISOString().slice(0,10),
-          open: Number(open_price),
-          high: Number(high_price),
-          low:  Number(low_price),
-          close: Number(price),
-        });
+    for (let cursor = new Date(start); cursor <= end; cursor.setUTCDate(cursor.getUTCDate() + 1)) {
+      const yyyymmdd = iso(cursor).replace(/-/g, '');
+      try {
+        const response = await goldApiClient.get(`/${SYMBOL_INFO.metal}/${SYMBOL_INFO.currency}/${yyyymmdd}`);
+        const data = response.data || {};
+        if (data?.error) throw new Error(data.error);
+        const base = {
+          date: iso(cursor),
+          open: toNumber(data.open_price, data.price),
+          high: toNumber(data.high_price, data.price),
+          low: toNumber(data.low_price, data.price),
+          close: toNumber(data.price ?? data.close_price, data.price),
+          symbol: SYMBOL_INFO.pair,
+        };
+        const normalized = normalizeOhlc(base);
+        if (normalized) {
+          rows.push({
+            date: normalized.date,
+            open: normalized.open,
+            high: normalized.high,
+            low: normalized.low,
+            close: normalized.close,
+          });
+        }
+      } catch (error) {
+        const status = error?.response?.status;
+        if (status === 404 || status === 422) {
+          console.warn(`GoldAPI sin datos para ${iso(cursor)} (${status})`);
+          continue;
+        }
+        throw error;
       }
     }
     if (!rows.length) throw new Error('Datos vacíos');
     res.json({ ok: true, rows });
-  } catch (e) {
-    res.status(502).json({ ok: false, error: 'Error en histórico', detail: e.message });
+  } catch (error) {
+    const detail = error?.response?.data?.error || error?.message || 'Error desconocido';
+    res.status(502).json({ ok: false, error: 'Error en histórico', detail });
   }
 });
 
@@ -102,54 +208,42 @@ app.get('/api/historical', async (req, res) => {
  * Body: [{date, open, high, low, close}]
  */
 app.post('/api/update-csv', async (req, res) => {
-  const incoming = req.body;
-  if (!Array.isArray(incoming) || !incoming.length) {
+  const incoming = Array.isArray(req.body) ? req.body : [];
+  if (!incoming.length) {
     return res.status(400).json({ ok: false, error: 'Cuerpo inválido' });
   }
 
-  // Leer CSV actual
-  const csvPath = path.resolve(CSV_PATH);
-  let content = '';
-  try {
-    content = fs.readFileSync(csvPath, 'utf-8');
-  } catch {
-    content = '';
-  }
+  const csvPath = CSV_PATH;
+  const map = readCsvAsMap(csvPath);
 
-  // Construir mapa con filas existentes
-  const map = new Map();
-  if (content.trim()) {
-    const lines = content.trim().split(/\r?\n/);
-    // Ignorar cabecera
-    for (let i = 1; i < lines.length; i++) {
-      const [date, symbol, open, high, low, close] = lines[i].split(',');
-      map.set(date, { date, symbol, open: Number(open), high: Number(high), low: Number(low), close: Number(close) });
-    }
-  }
-
-  // Añadir las nuevas filas, reemplazando si existe misma fecha
-  for (const r of incoming) {
-    const d = String(r.date).slice(0,10);
-    map.set(d, {
-      date: d,
-      symbol: SYMBOL,
-      open: Number(r.open),
-      high: Number(r.high),
-      low:  Number(r.low),
-      close: Number(r.close),
+  let changes = 0;
+  for (const rawRow of incoming) {
+    const normalized = normalizeOhlc({
+      date: rawRow?.date,
+      open: rawRow?.open,
+      high: rawRow?.high,
+      low: rawRow?.low,
+      close: rawRow?.close,
+      symbol: rawRow?.symbol,
     });
+    if (!normalized) continue;
+    const prev = map.get(normalized.date);
+    if (!prev || prev.open !== normalized.open || prev.high !== normalized.high || prev.low !== normalized.low || prev.close !== normalized.close) {
+      changes += 1;
+    }
+    map.set(normalized.date, { ...prev, ...normalized, symbol: normalized.symbol || prev?.symbol || SYMBOL_INFO.pair });
   }
 
-  // Ordenar y reconstruir CSV
-  const rows = Array.from(map.values()).sort((a,b) => a.date.localeCompare(b.date));
-  const header = 'date,symbol,open,high,low,close';
-  const out    = [header, ...rows.map(r => `${r.date},${r.symbol},${r.open},${r.high},${r.low},${r.close}`)].join('\n') + '\n';
+  if (!map.size) {
+    return res.status(400).json({ ok: false, error: 'Sin datos válidos para guardar' });
+  }
 
   try {
-    fs.writeFileSync(csvPath, out, 'utf-8');
-    res.json({ ok: true, added: incoming.length });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: 'Error al escribir CSV', detail: e.message });
+    const rows = writeMapToCsv(map, csvPath);
+    const last = rows[rows.length - 1];
+    res.json({ ok: true, updated: changes, totalRows: rows.length, lastDate: last?.date || null });
+  } catch (error) {
+    res.status(500).json({ ok: false, error: 'Error al escribir CSV', detail: error?.message || String(error) });
   }
 });
 

--- a/src/components/GoldCsvDashboard.jsx
+++ b/src/components/GoldCsvDashboard.jsx
@@ -253,7 +253,9 @@ export default function GoldCsvDashboard() {
             CSV: {CONFIG.CSV_URL ? <span className="font-medium">{CONFIG.CSV_URL}</span> : <span className="text-amber-700">sin URL</span>}
           </span>
         </div>
-        <div className="ml-auto text-xs text-gray-500">API key {CONFIG.API_KEY ? "presente" : "ausente"}</div>
+        <div className="ml-auto text-xs text-gray-500">
+          Backend {CONFIG.BACKEND_BASE ? `remoto (${CONFIG.BACKEND_BASE})` : 'local (mismo origen)'}
+        </div>
       </section>
 
       {/* Últimos datos (usa spot/ohlc si configuras API, si no, se basa en CSV) */}

--- a/src/config.js
+++ b/src/config.js
@@ -1,19 +1,14 @@
 // src/config.js
 
 // Estos valores se leen de variables de entorno de Vite (prefijadas con VITE_) o usan un valor por defecto.
-// API_BASE: dominio del proveedor (por defecto https://metals-api.com/api).
-// API_KEY : clave de Metals-API (por defecto cadena vacía, lo que indicará que no hay key).
-// SYMBOL  : par metal-divisa a consultar (por defecto XAUUSD).
-// CSV_URL : ubicación del CSV limpio en la carpeta /public/data.
-// REQUEST_DELAY_MS: retardo entre llamadas al API (para evitar límites).
+// BACKEND_BASE: dominio del backend Express (por defecto cadena vacía → mismo origen).
+// SYMBOL      : par metal-divisa a consultar (por defecto XAUUSD).
+// CSV_URL     : ubicación del CSV limpio en la carpeta /public/data.
 
-const API_BASE = import.meta.env.VITE_METALS_API_BASE || 'https://metals-api.com/api';
-const API_KEY  = import.meta.env.VITE_METALS_API_KEY  || '';
-const SYMBOL   = import.meta.env.VITE_SYMBOL          || 'XAUUSD';
-const CSV_URL  = import.meta.env.VITE_CSV_URL         || '/data/xauusd_ohlc_clean.csv';
-const REQUEST_DELAY_MS = Number(import.meta.env.VITE_REQUEST_DELAY_MS ?? 1100);
+const BACKEND_BASE = (import.meta.env.VITE_BACKEND_BASE || '').replace(/\/$/, '');
+const SYMBOL = import.meta.env.VITE_SYMBOL || 'XAUUSD';
+const CSV_URL = import.meta.env.VITE_CSV_URL || '/data/xauusd_ohlc_clean.csv';
 
 // Exportamos la configuración como objeto.
-// Otros módulos (como GoldNowSection) leerán CONFIG.API_KEY, CONFIG.API_BASE, etc.
-export const CONFIG = { API_BASE, API_KEY, SYMBOL, CSV_URL, REQUEST_DELAY_MS };
+export const CONFIG = { BACKEND_BASE, SYMBOL, CSV_URL };
 export default CONFIG;


### PR DESCRIPTION
## Summary
- update the Express server to consume GoldAPI, normalise OHLC rows, and merge CSV updates without duplicates
- refresh the frontend API helpers and GoldNowSection to call the new /api endpoints and display the backend spot price
- adjust dashboard messaging and docs to describe the backend base URL configuration

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c945aa67d4832d829f168286002a5e