### PR TITLE
Handle CSV parse errors before processing data

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -99,6 +99,12 @@ export async function loadCsvFromUrl(url) {
   if (!res.ok) throw new Error(`No se pudo cargar CSV (${res.status})`);
   const text = await res.text();
   const parsed = Papa.parse(text, { header: true, skipEmptyLines: true });
+  // Papa.parse puede retornar datos parciales aun cuando registra errores, por eso
+  // verificamos y fallamos temprano para evitar procesar datos inconsistentes.
+  if (parsed.errors && parsed.errors.length) {
+    console.error("Errores al parsear CSV", parsed.errors);
+    throw new Error("Papa.parse encontró errores en el CSV");
+  }
   const rows = (parsed.data || [])
     .map((r) => {
       const date = toDate(r.date || r.Date || r.timestamp || r.time);


### PR DESCRIPTION
## Summary
- add explicit error handling for CSV parsing results
- log and throw when Papa.parse reports errors to avoid processing invalid rows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c944698cf8832d978f8b73343ab9ef