### PR TITLE
Add caching and rate limiting to GoldAPI backend

### DIFF
--- a/README_FIX.txt
+++ b/README_FIX.txt
@@ -4,6 +4,8 @@ FIX: Netlify secrets scanning
 
 - Configura en Render (o el host donde corra `server/index.js`) las variables:
   - `GOLDAPI_KEY`, `GOLDAPI_BASE`, `SYMBOL`, `CSV_PATH`, `PORT` (opcional `GOLDAPI_TIMEOUT_MS`).
+  - Opcionales nuevos para controlar caché y rate limiting: `SPOT_CACHE_TTL_MS`,
+    `HISTORICAL_CACHE_TTL_MS`, `GOLDAPI_MIN_INTERVAL_MS`.
 - El frontend ahora llama a `/api/spot`, `/api/historical` y `/api/update-csv`.
   - En Netlify (scope Builds) define `VITE_BACKEND_BASE` si el backend vive en otro dominio.
 - Las claves ya **no se exponen** en el bundle del cliente; quedan en el backend.


### PR DESCRIPTION
## Summary
- add in-memory caching for spot responses to reuse recent data and fall back to stale values when GoldAPI rejects requests
- share historical fetches across clients, cache the results, and throttle outbound GoldAPI calls to stay under the provider rate limits
- document the new optional environment variables for cache TTLs and throttling in README_FIX

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c94b69deac832d9815a52042e42aab