### PR TITLE
Expose bid/ask spot prices in dashboard

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -81,9 +81,18 @@ export async function fetchSpotPrice() {
   }
   const price = num(json.price);
   if (!Number.isFinite(price) || price <= 0) throw new Error('Precio inválido');
+  const bid = num(json.bid);
+  const ask = num(json.ask);
   const tsValue = Number(json.ts);
   const ts = Number.isFinite(tsValue) ? new Date(tsValue) : new Date();
-  return { price, ts };
+  return {
+    price,
+    bid: Number.isFinite(bid) && bid > 0 ? bid : null,
+    ask: Number.isFinite(ask) && ask > 0 ? ask : null,
+    ts,
+    symbol: typeof json.symbol === 'string' && json.symbol ? json.symbol : null,
+    currency: typeof json.currency === 'string' && json.currency ? json.currency : null,
+  };
 }
 
 // ===== Helpers =====

--- a/src/components/GoldNowSection.jsx
+++ b/src/components/GoldNowSection.jsx
@@ -46,6 +46,8 @@ export default function GoldNowSection({ rows = [], onAppendRows, fetchMissingDa
   // Estado para el precio spot
   const [spot, setSpot] = useState(null);
   const [spotTs, setSpotTs] = useState(null);
+  const [spotBid, setSpotBid] = useState(null);
+  const [spotAsk, setSpotAsk] = useState(null);
   const [spotErr, setSpotErr] = useState('');
 
   // Formatea un Date a ISO (YYYY‑MM‑DD)
@@ -120,13 +122,17 @@ export default function GoldNowSection({ rows = [], onAppendRows, fetchMissingDa
    */
   const refreshSpot = useCallback(async () => {
     try {
-      const { price, ts } = await fetchSpotPrice();
+      const { price, ts, bid, ask } = await fetchSpotPrice();
       setSpot(price);
       setSpotTs(ts instanceof Date ? ts : new Date(ts));
+      setSpotBid(Number.isFinite(bid) ? bid : null);
+      setSpotAsk(Number.isFinite(ask) ? ask : null);
       setSpotErr('');
     } catch (e) {
       setSpot(null);
       setSpotTs(null);
+      setSpotBid(null);
+      setSpotAsk(null);
       setSpotErr(String(e?.message || e));
     }
   }, []);
@@ -208,6 +214,26 @@ export default function GoldNowSection({ rows = [], onAppendRows, fetchMissingDa
               </span>
             )}
           </div>
+          {Number.isFinite(spotBid) || Number.isFinite(spotAsk) ? (
+            <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-gray-600">
+              {Number.isFinite(spotBid) && (
+                <span>
+                  Compra (bid):{' '}
+                  <span className="font-medium text-gray-700">
+                    {spotBid.toLocaleString('es-ES', { maximumFractionDigits: 2 })}
+                  </span>
+                </span>
+              )}
+              {Number.isFinite(spotAsk) && (
+                <span>
+                  Venta (ask):{' '}
+                  <span className="font-medium text-gray-700">
+                    {spotAsk.toLocaleString('es-ES', { maximumFractionDigits: 2 })}
+                  </span>
+                </span>
+              )}
+            </div>
+          ) : null}
           <div className="text-[11px] text-gray-500 mt-1">
             {`Hoy ${iso(today)}`}
             {lastDateIso ? ` · último cierre CSV: ${lastDateIso}` : ''}


### PR DESCRIPTION
## Summary
- extend the `/api/spot` backend response to include bid/ask metadata alongside the latest price
- surface bid/ask data in the frontend API helper and show the formatted "Compra/Venta" values in the gold data widget

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c98bf6590c832d8db00c0bac2d1d3a