### PR TITLE
fix: lazy load finbert transformers

### DIFF
--- a/src/components/FloatingMenu.jsx
+++ b/src/components/FloatingMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState, useId } from 'react';
 
 import {
   Apple,
@@ -13,7 +13,248 @@ import {
   UserRoundPlus,
   Wallet
 } from 'lucide-react';
-import EmailSignupDialog from './EmailSignupDialog.jsx';
+const EMAIL_DIALOG_INITIAL_STATE = {
+  name: '',
+  lastName: '',
+  email: '',
+  company: '',
+  consent: false,
+};
+
+function EmailSignupDialog({ open, onClose }) {
+  const [formState, setFormState] = useState(EMAIL_DIALOG_INITIAL_STATE);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState('');
+  const dialogRef = useRef(null);
+  const firstFieldRef = useRef(null);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  const handleClose = useCallback(() => {
+    setFormState(EMAIL_DIALOG_INITIAL_STATE);
+    setStatus('idle');
+    setError('');
+    if (typeof onClose === 'function') {
+      onClose();
+    }
+  }, [onClose]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleKey = (event) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        handleClose();
+      }
+    };
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open, handleClose]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    let animationFrame;
+    const previousActiveElement = document.activeElement;
+    const focusDialog = () => {
+      if (firstFieldRef.current) {
+        firstFieldRef.current.focus({ preventScroll: true });
+      } else if (dialogRef.current) {
+        dialogRef.current.focus({ preventScroll: true });
+      }
+    };
+    animationFrame = requestAnimationFrame(focusDialog);
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      if (
+        previousActiveElement &&
+        typeof previousActiveElement.focus === 'function' &&
+        document.contains(previousActiveElement)
+      ) {
+        previousActiveElement.focus({ preventScroll: true });
+      }
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const handleFocus = (event) => {
+      if (dialogRef.current && !dialogRef.current.contains(event.target)) {
+        dialogRef.current.focus({ preventScroll: true });
+      }
+    };
+    document.addEventListener('focus', handleFocus, true);
+    return () => {
+      document.removeEventListener('focus', handleFocus, true);
+    };
+  }, [open]);
+
+  if (!open) {
+    return null;
+  }
+
+  const updateField = (field, value) => {
+    setFormState((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    const trimmedEmail = formState.email.trim();
+    const emailValid = /^(?:[a-z0-9_'^&+-]+)(?:\.[a-z0-9_'^&+-]+)*@(?:[a-z0-9-]+\.)+[a-z]{2,}$/i.test(trimmedEmail);
+    if (!emailValid) {
+      setError('Introduce un correo electrónico válido.');
+      if (firstFieldRef.current) {
+        firstFieldRef.current.focus({ preventScroll: true });
+      }
+      return;
+    }
+    if (!formState.consent) {
+      setError('Debes aceptar el tratamiento de datos para continuar.');
+      return;
+    }
+    setError('');
+    setStatus('success');
+  };
+
+  const handleBackdropPointerDown = (event) => {
+    if (event.target === event.currentTarget) {
+      handleClose();
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-slate-900/70 px-4 py-6 backdrop-blur"
+      role="presentation"
+      onMouseDown={handleBackdropPointerDown}
+      onTouchStart={handleBackdropPointerDown}
+    >
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+        className="relative w-full max-w-md rounded-3xl border border-white/20 bg-white/90 p-6 shadow-[0_32px_70px_rgba(15,23,42,0.35)] backdrop-blur-xl dark:border-white/10 dark:bg-slate-900/90"
+      >
+        <button
+          type="button"
+          className="absolute right-4 top-4 rounded-full border border-transparent bg-white/40 p-1.5 text-slate-700 transition hover:bg-white/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-700 dark:bg-white/10 dark:text-slate-200 dark:hover:bg-white/20"
+          onClick={handleClose}
+          aria-label="Cerrar registro por correo"
+        >
+          <ArrowUpRight className="h-4 w-4 rotate-45" />
+        </button>
+        <div className="space-y-2 text-center">
+          <span className="text-xs uppercase tracking-[0.3em] text-slate-500 dark:text-slate-400">KleverGold</span>
+          <h2 id={titleId} className="text-2xl font-semibold text-slate-900 dark:text-white">
+            Únete con tu correo electrónico
+          </h2>
+          <p id={descriptionId} className="text-sm text-slate-600 dark:text-slate-300">
+            Crea tu Klever ID en minutos con verificación instantánea y alertas personalizadas.
+          </p>
+        </div>
+        <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col text-left text-sm font-medium text-slate-700 dark:text-slate-200">
+              Nombre
+              <input
+                ref={firstFieldRef}
+                type="text"
+                value={formState.name}
+                onChange={(event) => updateField('name', event.target.value)}
+                className="mt-1 rounded-xl border border-slate-200/70 bg-white/60 px-3 py-2 text-sm text-slate-900 shadow-inner transition placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-white"
+                placeholder="Tu nombre"
+              />
+            </label>
+            <label className="flex flex-col text-left text-sm font-medium text-slate-700 dark:text-slate-200">
+              Apellidos
+              <input
+                type="text"
+                value={formState.lastName}
+                onChange={(event) => updateField('lastName', event.target.value)}
+                className="mt-1 rounded-xl border border-slate-200/70 bg-white/60 px-3 py-2 text-sm text-slate-900 shadow-inner transition placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-white"
+                placeholder="Tus apellidos"
+              />
+            </label>
+          </div>
+          <label className="flex flex-col text-left text-sm font-medium text-slate-700 dark:text-slate-200">
+            Correo electrónico
+            <input
+              type="email"
+              inputMode="email"
+              value={formState.email}
+              onChange={(event) => updateField('email', event.target.value)}
+              required
+              className="mt-1 rounded-xl border border-slate-200/70 bg-white/60 px-3 py-2 text-sm text-slate-900 shadow-inner transition placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-white"
+              placeholder="nombre@empresa.com"
+              aria-invalid={error ? 'true' : 'false'}
+            />
+          </label>
+          <label className="flex flex-col text-left text-sm font-medium text-slate-700 dark:text-slate-200">
+            Organización (opcional)
+            <input
+              type="text"
+              value={formState.company}
+              onChange={(event) => updateField('company', event.target.value)}
+              className="mt-1 rounded-xl border border-slate-200/70 bg-white/60 px-3 py-2 text-sm text-slate-900 shadow-inner transition placeholder:text-slate-400 focus:border-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-400 dark:border-white/10 dark:bg-slate-900/80 dark:text-white"
+              placeholder="Tu empresa o proyecto"
+            />
+          </label>
+          <label className="flex items-start gap-3 text-left text-xs text-slate-600 dark:text-slate-300">
+            <input
+              type="checkbox"
+              checked={formState.consent}
+              onChange={(event) => updateField('consent', event.target.checked)}
+              className="mt-0.5 h-4 w-4 rounded border border-slate-300 text-amber-500 focus:ring-amber-400"
+            />
+            <span>
+              Acepto la{' '}
+              <a href="#" className="font-medium underline">
+                política de privacidad
+              </a>{' '}
+              y recibir comunicaciones sobre KleverGold.
+            </span>
+          </label>
+          {error ? (
+            <p className="text-sm font-medium text-rose-500" role="alert">
+              {error}
+            </p>
+          ) : null}
+          {status === 'success' ? (
+            <div className="flex items-start gap-3 rounded-2xl border border-emerald-300/60 bg-emerald-50/80 p-3 text-sm text-emerald-800 shadow-inner">
+              <ShieldCheck className="mt-0.5 h-4 w-4" />
+              <span>
+                ¡Listo! Hemos registrado tu interés. Revisa tu bandeja de entrada para activar las alertas de Klever Orion.
+              </span>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-between gap-3 pt-2 text-xs text-slate-500 dark:text-slate-400">
+            <span>Seguridad empresarial con KleverShield®</span>
+            <span className="font-semibold text-slate-700 dark:text-slate-200">IA 100% supervisada</span>
+          </div>
+          <div className="flex flex-col gap-2 pt-2 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={handleClose}
+              className="inline-flex items-center justify-center rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition hover:border-slate-300 hover:text-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-400 dark:border-white/10 dark:text-slate-200 dark:hover:border-white/30"
+            >
+              Cancelar
+            </button>
+            <button
+              type="submit"
+              className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-amber-400 via-orange-400 to-amber-500 px-5 py-2 text-sm font-semibold text-slate-900 shadow-lg shadow-amber-500/30 transition hover:shadow-amber-500/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500"
+            >
+              {status === 'success' ? 'Registrado' : 'Crear cuenta con correo'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
 
 const SIGNUP_OPTIONS = [
   {

--- a/src/components/GoldNewsGlassCarousel.jsx
+++ b/src/components/GoldNewsGlassCarousel.jsx
@@ -1,109 +1,285 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ExternalLink, ChevronLeft, ChevronRight, Sparkles, RefreshCcw, Info, TrendingUp, Gauge, Clock, X } from 'lucide-react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import {
+  ExternalLink,
+  ChevronLeft,
+  ChevronRight,
+  Sparkles,
+  RefreshCcw,
+  Info,
+  TrendingUp,
+  Gauge,
+  Clock,
+  X,
+  Filter,
+  BarChart3,
+  Search,
+} from 'lucide-react';
 import { scoreNewsItems } from '../utils/newsMoE.js';
+import { summarize } from '../utils/newsSummarizer.js';
+import { classifyBias } from '../utils/newsBias.js';
+import { classifySentiment } from '../utils/finSentiment.js';
 
-/**
- * GoldNewsGlassCarousel — agregador premium con IA libre.
- * - Feed abierto vía Netlify Function con tolerancia a fallos.
- * - Escoring Mixture-of-Experts local con @xenova/transformers.
- * - Carrusel glassmorphism con sombras individuales y scroll-snap.
- * - Imágenes robustas (preload + skeleton + fallbacks temáticos) sin barra visible.
- */
-export default function GoldNewsGlassCarousel({ items, initialIndex = 1 }) {
+const CACHE_KEY = 'klever_orion_v2_news_cache';
+const CACHE_TTL_MS = 10 * 60 * 1000;
+const CIRCUIT_BREAK_MS = 60 * 1000;
+const MAX_RETRIES = 2;
+const FETCH_TIMEOUT_MS = 14_000;
+const SENTIMENT_FILTERS = ['all', 'bullish', 'neutral', 'bearish'];
+const BIAS_FILTERS = ['all', 'liberal', 'conservative', 'center', 'pro-market', 'anti-market'];
+const SORT_OPTIONS = [
+  { id: 'relevance', label: 'Ordenar por relevancia' },
+  { id: 'date', label: 'Ordenar por fecha' },
+];
+const FALLBACK_IMAGES = [
+  'https://images.unsplash.com/photo-1553729459-efe14ef6055d?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1593672715438-d88a70629abe?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1639322537228-f710d846310a?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1566943956303-74261c0f3760?q=80&w=1600&auto=format&fit=crop',
+];
+const EXPERT_ORDER = ['macro', 'etf', 'usd', 'cb'];
+const EXPERT_COLORS = {
+  macro: '#6366F1',
+  etf: '#22C55E',
+  usd: '#0EA5E9',
+  cb: '#F97316',
+  mix: '#94A3B8',
+};
+
+export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
   const [news, setNews] = useState(items ?? []);
   const [status, setStatus] = useState(items?.length ? 'ready' : 'idle');
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
   const [failures, setFailures] = useState([]);
-  const wrapRef = useRef(null);
-  const firstLoad = useRef(false);
-  const [active, setActive] = useState(initialIndex);
+  const [trend, setTrend] = useState(null);
   const [selected, setSelected] = useState(null);
+  const [filters, setFilters] = useState({ sentiment: 'all', bias: 'all' });
+  const [sortBy, setSortBy] = useState('relevance');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [active, setActive] = useState(initialIndex);
 
-  const displayItems = useMemo(() => {
-    if (items && items.length) return items;
-    return news;
-  }, [items, news]);
+  const wrapRef = useRef(null);
+  const pipelineRef = useRef({ promise: null, controller: null, failureCount: 0, openUntil: 0 });
+  const cacheRef = useRef(null);
+  const imageCacheRef = useRef(new Map());
+  const firstLoad = useRef(false);
+  const debouncedSearch = useDebouncedValue(searchTerm, 240);
 
-  const hasData = displayItems.length > 0;
+  const hasData = news.length > 0;
   const isLoading = status === 'loading';
   const isError = status === 'error';
   const isEmpty = status === 'empty';
 
+  const filteredItems = useMemo(() => {
+    if (!news.length) return [];
+    const sentimentFilter = filters.sentiment;
+    const biasFilter = filters.bias;
+    const term = debouncedSearch.trim().toLowerCase();
+
+    const filtered = news.filter((item) => {
+      if (sentimentFilter !== 'all' && item.sentiment !== sentimentFilter) return false;
+      if (biasFilter !== 'all' && item.biasLabel !== biasFilter) return false;
+      if (term) {
+        const haystack = `${item.title} ${item.executiveBrief} ${item.source} ${item.sourceDomain}`.toLowerCase();
+        if (!haystack.includes(term)) return false;
+      }
+      return true;
+    });
+
+    const sorted = filtered
+      .slice()
+      .sort((a, b) => {
+        if (sortBy === 'date') {
+          const byDate = (b.publishedAtMs || 0) - (a.publishedAtMs || 0);
+          if (byDate !== 0) return byDate;
+          const byRelevance = (b.relevance || 0) - (a.relevance || 0);
+          if (byRelevance !== 0) return byRelevance;
+        } else {
+          const byRelevance = (b.relevance || 0) - (a.relevance || 0);
+          if (byRelevance !== 0) return byRelevance;
+          const byDate = (b.publishedAtMs || 0) - (a.publishedAtMs || 0);
+          if (byDate !== 0) return byDate;
+        }
+        return a.id.localeCompare(b.id);
+      });
+
+    return sorted;
+  }, [news, filters, debouncedSearch, sortBy]);
+
+  const virtualizationWindow = useMemo(() => {
+    const size = filteredItems.length;
+    if (!size) return new Set();
+    const windowRadius = 4;
+    const start = Math.max(0, active - windowRadius);
+    const end = Math.min(size - 1, active + windowRadius);
+    const set = new Set();
+    for (let i = start; i <= end; i += 1) set.add(i);
+    return set;
+  }, [filteredItems.length, active]);
+
+  const cardsToRender = isLoading && !hasData
+    ? Array.from({ length: 6 }, (_, index) => ({ __skeleton: true, id: `skeleton-${index}` }))
+    : filteredItems;
+
+  const loadFromCache = useCallback(() => {
+    if (cacheRef.current) return cacheRef.current;
+    try {
+      const raw = sessionStorage.getItem(CACHE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed || parsed.expiresAt < Date.now()) return null;
+      cacheRef.current = parsed;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const writeCache = useCallback((payload) => {
+    cacheRef.current = payload;
+    try {
+      sessionStorage.setItem(CACHE_KEY, JSON.stringify(payload));
+    } catch {
+      /* noop */
+    }
+  }, []);
+
   const fetchNews = useCallback(async () => {
+    if (items && items.length) return;
+    const now = Date.now();
+    if (pipelineRef.current.openUntil > now) {
+      setStatus('error');
+      setError('Circuito temporalmente abierto por fallos consecutivos. Intenta más tarde.');
+      return;
+    }
+
+    if (pipelineRef.current.promise) {
+      return pipelineRef.current.promise;
+    }
+
+    const controller = new AbortController();
+    pipelineRef.current.controller?.abort();
+    pipelineRef.current.controller = controller;
     setStatus('loading');
     setRefreshing(true);
     setError('');
-    try {
-      const res = await fetch('/.netlify/functions/news-feed', { cache: 'no-cache' });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const payload = await res.json();
-      if (!payload?.ok || !Array.isArray(payload.items)) throw new Error('Respuesta inválida del feed');
-      const scored = await scoreNewsItems(payload.items);
-      setNews(scored);
-      setFailures(Array.isArray(payload.failures) ? payload.failures : []);
-      setStatus(scored.length ? 'ready' : 'empty');
-      setActive(scored.length > initialIndex ? initialIndex : 0);
-    } catch (err) {
-      setError(err.message || 'No se pudo cargar el feed.');
-      setNews([]);
-      setFailures([]);
-      setStatus('error');
-      setActive(0);
-      setSelected(null);
-    } finally {
-      setRefreshing(false);
-    }
-  }, [initialIndex]);
+
+    const task = (async () => {
+      try {
+        const base = await fetchAndAggregate(controller.signal);
+        const enriched = await orchestrateEnrichment(base.items, controller.signal, imageCacheRef.current);
+        const { clusters, trend: newTrend } = postProcessNews(enriched);
+
+        if (controller.signal.aborted) return;
+
+        if (clusters.length === 0) {
+          setNews([]);
+          setTrend(newTrend);
+          setFailures(base.failures);
+          setStatus('empty');
+          setActive(0);
+          writeCache({ items: [], failures: base.failures, trend: newTrend, expiresAt: Date.now() + CACHE_TTL_MS });
+          return;
+        }
+
+        setNews(clusters);
+        setTrend(newTrend);
+        setFailures(base.failures);
+        setStatus('ready');
+        setActive((prev) => (prev < clusters.length ? prev : 0));
+        writeCache({ items: clusters, failures: base.failures, trend: newTrend, expiresAt: Date.now() + CACHE_TTL_MS });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        const message = err?.message || 'No se pudo cargar el feed';
+        setError(message);
+        setStatus('error');
+        setNews([]);
+        setTrend(null);
+        setFailures([]);
+        pipelineRef.current.failureCount += 1;
+        if (pipelineRef.current.failureCount >= 3) {
+          pipelineRef.current.openUntil = Date.now() + CIRCUIT_BREAK_MS;
+        }
+      } finally {
+        setRefreshing(false);
+        pipelineRef.current.controller = null;
+        pipelineRef.current.promise = null;
+      }
+    })();
+
+    pipelineRef.current.promise = task;
+    return task;
+  }, [items, writeCache]);
 
   useEffect(() => {
     if (items && items.length) {
       setStatus('ready');
       setNews(items);
       setFailures([]);
-      setSelected(null);
+      setTrend(computeTrend(items));
       return;
     }
+
     if (!firstLoad.current) {
       firstLoad.current = true;
-      fetchNews();
+      const cached = loadFromCache();
+      if (cached?.items?.length) {
+        setNews(cached.items);
+        setTrend(cached.trend);
+        setFailures(cached.failures ?? []);
+        setStatus('ready');
+        setTimeout(() => { fetchNews(); }, 200);
+      } else {
+        fetchNews();
+      }
     }
-  }, [items, fetchNews]);
+  }, [items, fetchNews, loadFromCache]);
 
   useEffect(() => {
     const el = wrapRef.current;
-    if (!el || !hasData) return;
-    const handle = requestAnimationFrame(() => {
-      const card = el.querySelector('[data-card]');
-      if (!card) return;
-      const gap = 24;
-      const width = card.getBoundingClientRect().width;
-      const idx = initialIndex < displayItems.length ? initialIndex : 0;
-      const left = Math.max(0, idx * (width + gap) - (el.clientWidth - width) / 2);
-      el.scrollLeft = left;
-      setActive(idx);
-    });
-    return () => cancelAnimationFrame(handle);
-  }, [displayItems, hasData, initialIndex]);
+    if (!el || !filteredItems.length) return;
+    const card = el.querySelector('[data-card]');
+    if (!card) return;
+    const gap = 24;
+    const width = card.getBoundingClientRect().width;
+    const idx = active < filteredItems.length ? active : 0;
+    const left = Math.max(0, idx * (width + gap) - (el.clientWidth - width) / 2);
+    el.scrollTo({ left, behavior: 'smooth' });
+  }, [filteredItems.length, active]);
 
   useEffect(() => {
     const el = wrapRef.current;
-    if (!el || !hasData) return;
-    const io = new IntersectionObserver((entries) => {
-      const vis = entries
-        .filter((entry) => entry.isIntersecting)
-        .map((entry) => ({
-          idx: Number(entry.target.getAttribute('data-idx')),
-          ratio: entry.intersectionRatio,
-        }))
-        .sort((a, b) => b.ratio - a.ratio);
-      if (vis[0]) setActive(vis[0].idx);
-    }, { root: el, threshold: [0.55, 0.75, 0.95] });
-    el.querySelectorAll('[data-card]').forEach((card) => io.observe(card));
+    if (!el) return;
+    if (!filteredItems.length) return;
+
+    const io = new IntersectionObserver(
+      (entries) => {
+        const vis = entries
+          .filter((entry) => entry.isIntersecting)
+          .map((entry) => ({ idx: Number(entry.target.getAttribute('data-idx')), ratio: entry.intersectionRatio }))
+          .sort((a, b) => b.ratio - a.ratio);
+        if (vis[0]) setActive(vis[0].idx);
+      },
+      { root: el, threshold: [0.55, 0.75, 0.95] },
+    );
+
+    const nodes = el.querySelectorAll('[data-card]');
+    nodes.forEach((node) => io.observe(node));
     return () => io.disconnect();
-  }, [displayItems, hasData]);
+  }, [filteredItems]);
+
+  useEffect(() => () => {
+    pipelineRef.current.controller?.abort();
+  }, []);
 
   const scrollByCards = useCallback((dir = 1) => {
     const el = wrapRef.current;
@@ -114,218 +290,376 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 1 }) {
     el.scrollBy({ left: dir * (width + gap), behavior: 'smooth' });
   }, []);
 
-  const openInsight = useCallback((item) => {
+  const onSelectItem = useCallback((item) => {
     setSelected(item);
   }, []);
 
-  const closeInsight = useCallback(() => {
+  const onCloseModal = useCallback(() => {
     setSelected(null);
   }, []);
 
-  const cardsToRender = !hasData && isLoading ? Array.from({ length: 5 }, (_, i) => ({ __skeleton: true, id: `skeleton-${i}` })) : displayItems;
+  const updateSentimentFilter = useCallback((value) => {
+    setFilters((prev) => ({ ...prev, sentiment: value }));
+    setActive(0);
+  }, []);
+
+  const updateBiasFilter = useCallback((value) => {
+    setFilters((prev) => ({ ...prev, bias: value }));
+    setActive(0);
+  }, []);
+
+  const handleSortChange = useCallback((event) => {
+    setSortBy(event.target.value);
+    setActive(0);
+  }, []);
+
+  const handleSearchChange = useCallback((event) => {
+    setSearchTerm(event.target.value);
+  }, []);
 
   return (
     <>
-      <section className="relative rounded-3xl border border-black/5 bg-white p-4">
+      <section className="relative rounded-3xl border border-black/5 bg-white p-4 shadow-[0_20px_55px_rgba(15,23,42,0.08)]">
         <style>{`
-        .news-scroll { -ms-overflow-style: none; scrollbar-width: none; overflow-y: visible; }
-        .news-scroll::-webkit-scrollbar { display: none; height: 0; background: transparent; }
+          .news-scroll { -ms-overflow-style: none; scrollbar-width: none; overflow-y: visible; }
+          .news-scroll::-webkit-scrollbar { display: none; height: 0; background: transparent; }
         `}</style>
 
-      <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
-        <div className="flex items-center gap-2">
-          <div className="p-1.5 rounded-lg bg-black/5"><Sparkles className="w-4 h-4" /></div>
-          <div>
-            <h3 className="text-lg font-semibold tracking-tight">Últimas que mueven el oro</h3>
-            <p className="text-xs text-gray-500">IA 100% de Aisa Group CA · KleverOrion v.2.0</p>
+        <header className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="rounded-2xl bg-gradient-to-br from-amber-100 via-white to-amber-50 p-2 shadow-inner">
+              <Sparkles className="h-5 w-5 text-amber-600" aria-hidden="true" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold tracking-tight text-gray-900">Últimas que mueven el oro</h3>
+              <p className="text-xs font-medium uppercase tracking-[0.14em] text-gray-400">IA 100% de Aisa Group CA · KleverOrion v.2.0</p>
+            </div>
           </div>
-        </div>
-        <div className="flex items-center gap-2 text-xs text-gray-500">
-          {refreshing && <span className="text-indigo-600">Actualizando…</span>}
-          <button
-            type="button"
-            onClick={fetchNews}
-            disabled={isLoading}
-            className="inline-flex items-center gap-1 rounded-full border border-black/10 bg-white px-3 py-1 text-xs font-medium text-gray-700 transition hover:border-black/20 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <RefreshCcw className="h-3.5 w-3.5" /> Recargar
-          </button>
-        </div>
-      </div>
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            {refreshing && <span className="text-indigo-600">Actualizando…</span>}
+            <button
+              type="button"
+              onClick={fetchNews}
+              disabled={isLoading}
+              className="inline-flex items-center gap-1 rounded-full border border-black/10 bg-white px-3 py-1 text-xs font-medium text-gray-700 shadow-sm transition hover:border-black/20 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <RefreshCcw className="h-3.5 w-3.5" aria-hidden="true" /> Recargar
+            </button>
+          </div>
+        </header>
 
-      {failures.length > 0 && (
-        <div className="mb-3 text-xs text-amber-600">
-          Fuentes con incidencias: {failures.map((f) => f.name || f.source).join(', ')}.
-        </div>
-      )}
+        {trend && (
+          <TrendBanner trend={trend} />
+        )}
 
-      {isError && (
-        <div className="rounded-2xl border border-rose-200 bg-rose-50 px-4 py-6 text-center text-sm text-rose-700">
-          <p className="mb-3 font-medium">No pudimos actualizar el feed abierto.</p>
-          <p className="mb-4 text-rose-600">{error}</p>
-          <button
-            type="button"
-            onClick={fetchNews}
-            className="inline-flex items-center gap-1 rounded-full bg-rose-600 px-4 py-2 text-white shadow hover:bg-rose-500"
-          >
-            Reintentar
-          </button>
-        </div>
-      )}
+        <ControlsBar
+          filters={filters}
+          onSentimentChange={updateSentimentFilter}
+          onBiasChange={updateBiasFilter}
+          sortBy={sortBy}
+          onSortChange={handleSortChange}
+          searchTerm={searchTerm}
+          onSearchChange={handleSearchChange}
+        />
 
-      {!isError && (
-        <div className="relative">
-          <button
-            aria-label="Anterior"
-            onClick={() => scrollByCards(-1)}
-            className="hidden sm:flex absolute left-[-18px] top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-white/95 ring-1 ring-black/5 shadow hover:bg-white"
-          >
-            <ChevronLeft className="w-5 h-5" />
-          </button>
-          <button
-            aria-label="Siguiente"
-            onClick={() => scrollByCards(1)}
-            className="hidden sm:flex absolute right-[-18px] top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-white/95 ring-1 ring-black/5 shadow hover:bg-white"
-          >
-            <ChevronRight className="w-5 h-5" />
-          </button>
+        {failures.length > 0 && (
+          <div className="mb-3 text-xs text-amber-600">
+            Fuentes con incidencias: {failures.map((f) => f.name || f.source).join(', ')}.
+          </div>
+        )}
 
-          <div className="pointer-events-none absolute inset-y-0 left-0 w-14 bg-gradient-to-r from-white to-transparent" />
-          <div className="pointer-events-none absolute inset-y-0 right-0 w-14 bg-gradient-to-l from-white to-transparent" />
+        {isError && (
+          <div className="mt-4 rounded-3xl border border-rose-200 bg-rose-50 px-5 py-8 text-center text-sm text-rose-700">
+            <p className="mb-3 font-semibold">No pudimos actualizar el feed abierto.</p>
+            <p className="mb-4 text-rose-600">{error}</p>
+            <button
+              type="button"
+              onClick={fetchNews}
+              className="inline-flex items-center gap-2 rounded-full bg-rose-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-rose-500"
+            >
+              Reintentar
+            </button>
+          </div>
+        )}
 
-          <div ref={wrapRef} className="news-scroll flex gap-6 overflow-x-auto snap-x snap-mandatory pb-8 px-16">
-            {cardsToRender.length === 0 && !isLoading && (
-              <div className="min-h-[200px] flex items-center justify-center text-sm text-gray-500">
-                Sin titulares recientes. Intenta recargar en unos minutos.
-              </div>
-            )}
-            {cardsToRender.map((it, idx) => (
-              it.__skeleton ? (
-                <SkeletonCard key={it.id} />
-              ) : (
-                <article
-                  key={it.id || idx}
-                  data-card
-                  data-idx={idx}
-                  className="group min-w-[320px] max-w-[360px] snap-center cursor-pointer outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60 focus-visible:ring-offset-2"
-                  role="button"
-                  tabIndex={0}
-                  aria-label={`Ampliar resumen de ${it.title}`}
-                  onClick={() => openInsight(it)}
-                  onKeyDown={(evt) => {
-                    if (evt.key === 'Enter' || evt.key === ' ') {
-                      evt.preventDefault();
-                      openInsight(it);
-                    }
-                  }}
-                >
-                  <div className="relative px-2">
-                    <div className="pointer-events-none absolute inset-x-8 -bottom-2 h-6 rounded-full bg-black/10 blur-lg transition group-hover:blur-xl" />
-                    <div className="relative rounded-3xl overflow-hidden ring-1 ring-black/5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] group-hover:shadow-[0_14px_30px_rgba(0,0,0,0.12)] transition-all duration-300">
-                      <Thumb src={it.image} alt={it.title} idx={idx} />
-                      <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2">
-                        {it.sourceLogo && (
-                          <span className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-white/50 bg-white/80 shadow-sm">
-                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                            <img
-                              src={it.sourceLogo}
-                              alt={`${it.source} logo`}
-                              className="h-full w-full object-contain"
-                              loading="lazy"
-                              referrerPolicy="no-referrer"
-                              onError={(event) => {
-                                event.currentTarget.style.display = 'none';
-                              }}
-                            />
-                          </span>
-                        )}
-                        {it.sourceCategory && (
-                          <span className="rounded-full bg-black/60 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
-                            {it.sourceCategory}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+        {!isError && (
+          <div className="relative">
+            <button
+              type="button"
+              aria-label="Anterior"
+              onClick={() => scrollByCards(-1)}
+              className="absolute left-[-18px] top-1/2 hidden -translate-y-1/2 rounded-full bg-white/95 p-2 text-gray-600 shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 sm:flex"
+            >
+              <ChevronLeft className="h-5 w-5" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              aria-label="Siguiente"
+              onClick={() => scrollByCards(1)}
+              className="absolute right-[-18px] top-1/2 hidden -translate-y-1/2 rounded-full bg-white/95 p-2 text-gray-600 shadow transition hover:bg-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 sm:flex"
+            >
+              <ChevronRight className="h-5 w-5" aria-hidden="true" />
+            </button>
 
-                  <div className="relative -mt-6 rounded-3xl border border-white/20 bg-white/70 backdrop-blur-xl px-4 pt-4 pb-5 shadow-[0_10px_22px_rgba(0,0,0,0.08)] transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[0_18px_38px_rgba(0,0,0,0.14)]">
-                    <header className="mb-3 flex items-start justify-between gap-3 text-[11px] text-gray-500">
-                      <div className="flex items-start gap-2">
-                        <div className="flex flex-col">
-                          <span className="text-xs font-semibold text-indigo-600">{it.source}</span>
-                          <span className="text-[10px] text-gray-400">{it.publishedAt}</span>
-                        </div>
-                      </div>
-                      {it.link && (
-                        <a
-                          href={it.link}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="inline-flex items-center gap-1 text-gray-600 transition hover:text-gray-800"
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          Leer <ExternalLink className="w-3.5 h-3.5" />
-                        </a>
-                      )}
-                    </header>
+            <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white to-transparent" />
+            <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white to-transparent" />
 
-                    <h4 className="mb-2 text-[17px] font-semibold leading-snug text-gray-900 line-clamp-2">{it.title}</h4>
-                    <p className="mb-2 text-sm text-gray-700 line-clamp-3">{it.insight?.effect || it.reason}</p>
-                    {it.insight?.recency && (
-                      <p className="mb-2 text-[11px] text-gray-500 line-clamp-2">{it.insight.recency}</p>
-                    )}
-                    {it.insight?.signals && (
-                      <p className="mb-3 text-[11px] text-gray-500">{it.insight.signals}</p>
-                    )}
+            <div ref={wrapRef} className="news-scroll mt-4 flex gap-6 overflow-x-auto px-12 pb-10">
+              {cardsToRender.length === 0 && !isLoading && (
+                <div className="min-h-[220px] w-full rounded-2xl border border-gray-200 bg-gray-50/60 p-6 text-center text-sm text-gray-500">
+                  Sin titulares recientes. Intenta recargar en unos minutos.
+                </div>
+              )}
 
-                    <div className="mb-3 flex flex-wrap gap-2">
-                      <Badge tone={toneBySent(it.sentiment)}>{labelSent(it.sentiment)}</Badge>
-                      <Badge tone={toneByImpact(it.impact)}>Impacto: {labelImpact(it.impact)}</Badge>
-                      <Badge tone="secondary">Sesgo: {it.bias}</Badge>
-                    </div>
+              {cardsToRender.map((item, idx) => {
+                if (item.__skeleton) {
+                  return <SkeletonCard key={item.id} />;
+                }
 
-                    <div className="grid grid-cols-2 gap-3">
-                      <Meter label="Relevancia" value={it.relevance} />
-                      <Meter label="Confianza" value={it.confidence} />
-                    </div>
+                const shouldRender = virtualizationWindow.size ? virtualizationWindow.has(idx) : true;
+                if (!shouldRender) {
+                  return <VirtualPlaceholder key={item.id} />;
+                }
 
-                    <div className="mt-4 inline-flex items-center gap-1 text-[11px] font-semibold text-indigo-600">
-                      <Sparkles className="h-3.5 w-3.5" /> Ver resumen IA
-                    </div>
-                  </div>
-                </article>
-              )
+                return (
+                  <NewsCard
+                    key={item.id}
+                    item={item}
+                    index={idx}
+                    isActive={idx === active}
+                    onSelect={onSelectItem}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {!isError && hasData && (
+          <div className="mt-3 flex items-center justify-center gap-1.5" role="tablist" aria-label="Posición en carrusel">
+            {filteredItems.map((_, index) => (
+              <span
+                key={index}
+                role="tab"
+                aria-selected={index === active}
+                className={`h-1.5 rounded-full transition-all ${index === active ? 'w-6 bg-gray-800' : 'w-2 bg-gray-300'}`}
+              />
             ))}
           </div>
-        </div>
-      )}
+        )}
 
-      {!isError && hasData && (
-        <div className="mt-3 flex items-center justify-center gap-1.5">
-          {displayItems.map((_, i) => (
-            <span
-              key={i}
-              className={`h-1.5 rounded-full transition-all ${i === active ? 'w-6 bg-gray-800' : 'w-2 bg-gray-300'}`}
-            />
-          ))}
-        </div>
-      )}
+        {isEmpty && !isLoading && (
+          <div className="mt-4 text-center text-xs text-gray-500">El agregador no encontró titulares únicos en las últimas horas.</div>
+        )}
+      </section>
 
-      {isEmpty && !isLoading && (
-        <div className="mt-4 text-center text-xs text-gray-500">El agregador no encontró titulares únicos en las últimas horas.</div>
-      )}
-    </section>
       {selected && (
-        <InsightModal item={selected} onClose={closeInsight} />
+        <InsightModal item={selected} onClose={onCloseModal} />
       )}
     </>
   );
 }
 
+function TrendBanner({ trend }) {
+  return (
+    <div className="mt-4 rounded-3xl border border-indigo-100 bg-indigo-50/80 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <div className="rounded-full bg-white/70 p-2 shadow-inner">
+            <BarChart3 className="h-4 w-4 text-indigo-600" aria-hidden="true" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-indigo-500">Tendencias de expertos</p>
+            <p className="text-sm text-indigo-900">{trend.microCopy}</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 text-[11px] text-indigo-600">
+          <TrendingUp className="h-3.5 w-3.5" aria-hidden="true" />
+          {trend.keywords.length > 0 && (
+            <span className="truncate">Palabras clave: {trend.keywords.slice(0, 4).join(', ')}</span>
+          )}
+        </div>
+      </div>
+      <div className="mt-3 flex h-2 overflow-hidden rounded-full bg-white/60">
+        {trend.sequence.map((segment) => (
+          <div
+            key={segment.key}
+            title={`${segment.label}: ${(segment.share * 100).toFixed(0)}%`}
+            style={{ width: `${Math.max(2, segment.share * 100)}%`, background: segment.background }}
+            className="transition-all"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ControlsBar({ filters, onSentimentChange, onBiasChange, sortBy, onSortChange, searchTerm, onSearchChange }) {
+  return (
+    <div className="mt-4 grid gap-3 rounded-3xl border border-gray-100 bg-gray-50/80 p-4 text-xs text-gray-600 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] lg:items-center">
+      <div className="flex flex-wrap items-center gap-2">
+        <Filter className="h-3.5 w-3.5 text-gray-500" aria-hidden="true" />
+        <span className="font-semibold uppercase tracking-[0.18em] text-gray-500">Impacto directo</span>
+        <div className="flex flex-wrap gap-1">
+          {SENTIMENT_FILTERS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onSentimentChange(option)}
+              className={`rounded-full px-2.5 py-1 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${filters.sentiment === option ? 'bg-emerald-100 text-emerald-700' : 'bg-white text-gray-600 hover:text-gray-800'}`}
+            >
+              {labelSent(option)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-semibold uppercase tracking-[0.18em] text-gray-500">Sesgo</span>
+        <div className="flex flex-wrap gap-1">
+          {BIAS_FILTERS.map((option) => (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onBiasChange(option)}
+              className={`rounded-full px-2.5 py-1 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500 ${filters.bias === option ? 'bg-indigo-100 text-indigo-700' : 'bg-white text-gray-600 hover:text-gray-800'}`}
+            >
+              {labelBias(option)}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400" aria-hidden="true" />
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={onSearchChange}
+            placeholder="Buscar titulares o señales"
+            aria-label="Buscar titulares"
+            className="h-9 w-full rounded-full border border-gray-200 bg-white pl-9 pr-3 text-xs text-gray-700 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-500/60"
+          />
+        </div>
+        <select
+          value={sortBy}
+          onChange={onSortChange}
+          className="h-9 rounded-full border border-gray-200 bg-white px-3 text-xs font-medium text-gray-700 focus:border-indigo-400 focus:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          aria-label="Ordenar titulares"
+        >
+          {SORT_OPTIONS.map((option) => (
+            <option key={option.id} value={option.id}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}
+
+function NewsCard({ item, index, isActive, onSelect }) {
+  const confidenceAlpha = calcConfidenceAlpha(item.confidence, item.sentimentScore);
+  const biasTone = item.biasLabel === 'pro-market' ? 'accent' : item.biasLabel === 'anti-market' ? 'danger' : 'secondary';
+  const stackCount = item.stackSize > 1 ? item.stackSize : 0;
+  return (
+    <article
+      key={item.id}
+      data-card
+      data-idx={index}
+      role="button"
+      tabIndex={0}
+      aria-label={`Ampliar resumen de ${item.title}`}
+      onClick={() => onSelect(item)}
+      onKeyDown={(evt) => {
+        if (evt.key === 'Enter' || evt.key === ' ') {
+          evt.preventDefault();
+          onSelect(item);
+        }
+      }}
+      className={`group min-w-[320px] max-w-[360px] snap-center outline-none focus-visible:ring-2 focus-visible:ring-indigo-500/60 focus-visible:ring-offset-2 ${isActive ? 'scale-[1.02]' : ''}`}
+    >
+      <div className="relative px-2">
+        <div className="pointer-events-none absolute inset-x-8 -bottom-2 h-6 rounded-full bg-black/10 blur-lg transition group-hover:blur-xl" />
+        <div className="relative overflow-hidden rounded-3xl ring-1 ring-black/5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] transition-all duration-300 group-hover:shadow-[0_18px_36px_rgba(15,23,42,0.18)]">
+          <Thumb src={item.image} alt={item.title} idx={index} />
+          <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2">
+            {item.sourceLogo && (
+              <span className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-white/60 bg-white/80 shadow-sm">
+                <img
+                  src={item.sourceLogo}
+                  alt={`${item.source} logo`}
+                  className="h-full w-full object-contain"
+                  loading="lazy"
+                  referrerPolicy="no-referrer"
+                  onError={(event) => {
+                    event.currentTarget.style.display = 'none';
+                  }}
+                />
+              </span>
+            )}
+            {item.sourceCategory && (
+              <span className="rounded-full bg-black/60 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-white">
+                {item.sourceCategory}
+              </span>
+            )}
+          </div>
+          {stackCount > 0 && (
+            <span className="pointer-events-none absolute right-3 top-3 rounded-full bg-white/85 px-2 py-0.5 text-[10px] font-semibold text-gray-700 shadow">{`+${stackCount - 1}`}</span>
+          )}
+        </div>
+      </div>
+
+      <div className="relative -mt-6 rounded-3xl border border-white/20 bg-white/75 px-4 pt-4 pb-5 shadow-[0_10px_22px_rgba(0,0,0,0.1)] backdrop-blur-xl transition duration-300 group-hover:-translate-y-1 group-hover:shadow-[0_18px_38px_rgba(15,23,42,0.22)]">
+        <header className="mb-3 flex items-start justify-between gap-3 text-[11px] text-gray-500">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-xs font-semibold text-indigo-600">{item.source}</span>
+            <span className="text-[10px] text-gray-400">{item.relativeDate}</span>
+          </div>
+          {item.link && (
+            <a
+              href={item.link}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-gray-600 transition hover:text-gray-800"
+              onClick={(event) => event.stopPropagation()}
+            >
+              Leer <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          )}
+        </header>
+
+        <h4 className="mb-2 text-[17px] font-semibold leading-snug text-gray-900 line-clamp-2">{item.title}</h4>
+        <p className="mb-2 text-sm text-gray-700 line-clamp-3">{item.executiveBrief}</p>
+        {item.moeInsight?.recency && (
+          <p className="mb-2 text-[11px] text-gray-500 line-clamp-2">{item.moeInsight.recency}</p>
+        )}
+        {item.moeInsight?.signals && (
+          <p className="mb-3 text-[11px] text-gray-500">{item.moeInsight.signals}</p>
+        )}
+
+        <div className="mb-3 flex flex-wrap gap-2">
+          <Badge tone={toneBySent(item.sentiment)} intensity={confidenceAlpha}>{labelSent(item.sentiment)}</Badge>
+          <Badge tone={toneByImpact(item.impactLevel)}>{`Impacto ${labelImpact(item.impactLevel)}`}</Badge>
+          <Badge tone={biasTone} intensity={Math.max(0.6, item.biasScore)}>{`Sesgo ${labelBias(item.biasLabel)}`}</Badge>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 text-xs">
+          <Meter label="Relevancia" value={item.relevance} />
+          <Meter label="Confianza" value={item.confidence} />
+        </div>
+
+        <div className="mt-4 inline-flex items-center gap-1 text-[11px] font-semibold text-indigo-600">
+          <Sparkles className="h-3.5 w-3.5" aria-hidden="true" /> Ver resumen IA
+        </div>
+      </div>
+    </article>
+  );
+}
+
 function InsightModal({ item, onClose }) {
   useEffect(() => {
-    const handleKey = (evt) => {
-      if (evt.key === 'Escape') onClose();
+    const handleKey = (event) => {
+      if (event.key === 'Escape') onClose();
     };
     window.addEventListener('keydown', handleKey);
     const previousOverflow = document.body.style.overflow;
@@ -337,24 +671,18 @@ function InsightModal({ item, onClose }) {
   }, [onClose]);
 
   if (!item) return null;
-
-  const experts = Array.isArray(item.experts) ? item.experts.slice(0, 3) : [];
+  const experts = Array.isArray(item.experts) ? item.experts : [];
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-8 backdrop-blur-sm"
-      onClick={onClose}
-    >
-      <div
-        className="relative w-full max-w-4xl overflow-hidden rounded-3xl bg-white shadow-2xl"
-        onClick={(event) => event.stopPropagation()}
-      >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-8 backdrop-blur-sm" onClick={onClose} role="dialog" aria-modal="true" aria-label={`Detalle de ${item.title}`}>
+      <div className="relative w-full max-w-5xl overflow-hidden rounded-3xl bg-white shadow-2xl" onClick={(event) => event.stopPropagation()}>
         <button
           type="button"
           onClick={onClose}
-          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/5 text-gray-700 transition hover:bg-black/10"
+          className="absolute right-4 top-4 inline-flex h-9 w-9 items-center justify-center rounded-full bg-black/5 text-gray-700 transition hover:bg-black/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-500"
+          aria-label="Cerrar"
         >
-          <X className="h-4 w-4" />
+          <X className="h-4 w-4" aria-hidden="true" />
         </button>
 
         <div className="grid gap-6 md:grid-cols-[1.1fr_1fr]">
@@ -363,7 +691,6 @@ function InsightModal({ item, onClose }) {
             <div className="pointer-events-none absolute left-4 top-4 flex items-center gap-2">
               {item.sourceLogo && (
                 <span className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/60 bg-white/80 shadow">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
                     src={item.sourceLogo}
                     alt={`${item.source} logo`}
@@ -384,33 +711,67 @@ function InsightModal({ item, onClose }) {
             </div>
           </div>
 
-          <div className="space-y-4 p-6">
-            <div className="flex flex-wrap items-center gap-3">
-              <div className="flex flex-col text-sm">
-                <span className="text-xs uppercase tracking-wide text-gray-400">{formatDomain(item.sourceSite) || 'Fuente'}</span>
+          <div className="space-y-4 p-6 text-sm text-gray-700">
+            <div className="flex flex-wrap items-center gap-3 text-sm">
+              <div className="flex flex-col">
+                <span className="text-xs uppercase tracking-wide text-gray-400">{item.sourceDomain || 'Fuente'}</span>
                 <span className="text-base font-semibold text-gray-900">{item.source}</span>
-                {item.insight?.origin && (
-                  <span className="text-xs text-gray-500">{item.insight.origin}</span>
+                {item.moeInsight?.origin && (
+                  <span className="text-xs text-gray-500">{item.moeInsight.origin}</span>
                 )}
               </div>
+              <Badge tone={toneBySent(item.sentiment)} intensity={calcConfidenceAlpha(item.confidence, item.sentimentScore)}>{labelSent(item.sentiment)}</Badge>
+              <Badge tone={toneByImpact(item.impactLevel)}>{`Impacto ${labelImpact(item.impactLevel)}`}</Badge>
+              <Badge tone={item.biasLabel === 'pro-market' ? 'accent' : item.biasLabel === 'anti-market' ? 'danger' : 'secondary'} intensity={Math.max(0.6, item.biasScore)}>
+                {`Sesgo ${labelBias(item.biasLabel)}`}
+              </Badge>
             </div>
 
             <h3 className="text-xl font-semibold leading-tight text-gray-900">{item.title}</h3>
 
-            <InsightSection icon={Info} title="Resumen" text={item.insight?.summary || item.summaryHint} />
-            <InsightSection icon={TrendingUp} title="Impacto sobre el oro" text={item.insight?.effect} />
-            <InsightSection icon={Sparkles} title="Por qué la IA la seleccionó" text={item.insight?.why} />
-            <InsightSection icon={Gauge} title="Señales cuantitativas" text={item.insight?.signals} />
-            <InsightSection icon={Clock} title="Recencia" text={item.insight?.recency} />
+            <InsightSection icon={Info} title="Resumen ejecutivo" text={item.executiveBrief} />
+            <InsightSection icon={TrendingUp} title="Impacto sobre el oro" text={item.moeInsight?.effect} />
+            <InsightSection icon={Sparkles} title="Por qué la IA la seleccionó" text={item.moeInsight?.why} />
+            <InsightSection icon={Gauge} title="Señales cuantitativas" text={item.moeInsight?.signals} />
+            <InsightSection icon={Clock} title="Recencia" text={item.moeInsight?.recency} />
+            <InsightSection icon={Info} title="Por qué importa" text={item.whyMatters} />
+
+            {item.keywords?.length > 0 && (
+              <div className="rounded-2xl border border-gray-200 bg-gray-50/80 p-3 text-xs text-gray-600">
+                <p className="mb-1 font-semibold text-gray-800">Palabras clave detectadas</p>
+                <p>{item.keywords.slice(0, 8).join(', ')}</p>
+              </div>
+            )}
 
             {experts.length > 0 && (
               <div className="rounded-2xl border border-indigo-100 bg-indigo-50/60 p-3 text-xs text-indigo-800">
                 <p className="mb-2 font-semibold text-indigo-900">Peso de expertos</p>
                 <ul className="space-y-1">
                   {experts.map((expert) => (
-                    <li key={expert.id} className="flex items-center justify-between">
+                    <li key={expert.id} className="flex items-center justify-between gap-3">
                       <span>{expert.label}</span>
-                      <span>{Math.round((expert.alpha ?? 0) * 100)}%</span>
+                      <span className="font-semibold">{Math.round((expert.alpha ?? 0) * 100)}%</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {item.stack?.length > 1 && (
+              <div className="rounded-2xl border border-amber-100 bg-amber-50/70 p-3 text-xs text-amber-800">
+                <p className="mb-2 font-semibold text-amber-900">Variaciones equivalentes detectadas</p>
+                <ul className="space-y-1">
+                  {item.stack.slice(1).map((alt) => (
+                    <li key={alt.id} className="flex items-center justify-between gap-3">
+                      <span className="line-clamp-1">{alt.title}</span>
+                      <a
+                        href={alt.link}
+                        className="inline-flex items-center gap-1 text-amber-700 underline transition hover:text-amber-900"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Leer <ExternalLink className="h-3 w-3" aria-hidden="true" />
+                      </a>
                     </li>
                   ))}
                 </ul>
@@ -429,7 +790,7 @@ function InsightModal({ item, onClose }) {
                 rel="noopener noreferrer"
                 className="inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-indigo-500"
               >
-                Ir a la fuente original <ExternalLink className="h-4 w-4" />
+                Ir a la fuente original <ExternalLink className="h-4 w-4" aria-hidden="true" />
               </a>
             )}
           </div>
@@ -444,7 +805,7 @@ function InsightSection({ icon: Icon, title, text }) {
   return (
     <div className="rounded-2xl border border-gray-200 bg-gray-50/80 p-3 text-sm text-gray-700">
       <div className="mb-1 flex items-center gap-2 text-gray-900">
-        <Icon className="h-4 w-4 text-indigo-600" />
+        <Icon className="h-4 w-4 text-indigo-600" aria-hidden="true" />
         <span className="font-semibold">{title}</span>
       </div>
       <p>{text}</p>
@@ -452,14 +813,8 @@ function InsightSection({ icon: Icon, title, text }) {
   );
 }
 
-function formatDomain(url) {
-  if (!url) return '';
-  try {
-    const { hostname } = new URL(url.startsWith('http') ? url : `https://${url}`);
-    return hostname.replace(/^www\./, '');
-  } catch {
-    return url.replace(/^https?:\/\//, '').split('/')[0];
-  }
+function VirtualPlaceholder() {
+  return <div className="min-w-[320px] max-w-[360px]" aria-hidden="true" />;
 }
 
 function SkeletonCard() {
@@ -509,7 +864,6 @@ function SkeletonCard() {
   );
 }
 
-/* =============== Thumbnail robusto (preload + skeleton + fallback) =============== */
 function Thumb({ src, alt, idx = 0 }) {
   const [okSrc, setOkSrc] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -517,71 +871,765 @@ function Thumb({ src, alt, idx = 0 }) {
   useEffect(() => {
     let alive = true;
     const candidate = src || '';
+    if (!candidate) {
+      setOkSrc(FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]);
+      setLoading(false);
+      return () => {
+        alive = false;
+      };
+    }
     const img = new Image();
     img.referrerPolicy = 'no-referrer';
-    img.onload = () => { if (alive) { setOkSrc(candidate); setLoading(false); } };
-    img.onerror = () => { if (alive) { setOkSrc(FALLBACKS[idx % FALLBACKS.length]); setLoading(false); } };
-    if (candidate) img.src = candidate; else { setOkSrc(FALLBACKS[idx % FALLBACKS.length]); setLoading(false); }
-    return () => { alive = false; };
+    img.onload = () => {
+      if (alive) {
+        setOkSrc(candidate);
+        setLoading(false);
+      }
+    };
+    img.onerror = () => {
+      if (alive) {
+        setOkSrc(FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]);
+        setLoading(false);
+      }
+    };
+    img.src = candidate;
+    return () => {
+      alive = false;
+    };
   }, [src, idx]);
 
   return (
-    <div className="aspect-[16/9] w-full bg-gray-100 relative">
+    <div className="relative aspect-[16/9] w-full bg-gray-100">
       {loading && <div className="absolute inset-0 animate-pulse bg-gray-200" />}
-      {/* eslint-disable-next-line @next/next/no-img-element */}
       <img
-        src={okSrc || FALLBACKS[idx % FALLBACKS.length]}
+        src={okSrc || FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]}
         alt={alt || 'thumbnail'}
         className="h-full w-full object-cover"
         loading="lazy"
         referrerPolicy="no-referrer"
         onLoad={() => setLoading(false)}
-        onError={() => { setOkSrc(FALLBACKS[(idx + 1) % FALLBACKS.length]); setLoading(false); }}
+        onError={() => {
+          setOkSrc(FALLBACK_IMAGES[(idx + 1) % FALLBACK_IMAGES.length]);
+          setLoading(false);
+        }}
       />
     </div>
   );
 }
 
-/* =================== Subcomponentes =================== */
-function Badge({ tone='secondary', children }) {
-  const map = {
-    success:'bg-emerald-50 border-emerald-200 text-emerald-700',
-    danger:'bg-rose-50 border-rose-200 text-rose-700',
-    warning:'bg-amber-50 border-amber-200 text-amber-700',
-    accent:'bg-indigo-50 border-indigo-200 text-indigo-700',
-    secondary:'bg-gray-50 border-gray-200 text-gray-700'
+function Badge({ tone = 'secondary', intensity = 1, children }) {
+  const toneMap = {
+    success: 'bg-emerald-50 border-emerald-200 text-emerald-700',
+    danger: 'bg-rose-50 border-rose-200 text-rose-700',
+    warning: 'bg-amber-50 border-amber-200 text-amber-700',
+    accent: 'bg-indigo-50 border-indigo-200 text-indigo-700',
+    secondary: 'bg-gray-50 border-gray-200 text-gray-700',
   };
-  return <span className={`px-2 py-0.5 rounded-full border text-[10px] font-medium ${map[tone] || map.secondary}`}>{children}</span>;
+  const opacity = Math.min(1, Math.max(0.45, intensity));
+  return (
+    <span
+      className={`rounded-full border px-2 py-0.5 text-[10px] font-medium ${toneMap[tone] || toneMap.secondary}`}
+      style={{ opacity }}
+    >
+      {children}
+    </span>
+  );
 }
+
 function Meter({ label, value }) {
-  const pct = Math.round((Number(value) || 0)*100);
+  const pct = Math.round((Number(value) || 0) * 100);
   return (
     <div className="text-xs">
-      <div className="flex items-center justify-between mb-1"><span className="text-gray-600">{label}</span><span className="font-semibold">{pct}%</span></div>
-      <div className="h-2 rounded-full bg-gray-200 overflow-hidden">
+      <div className="mb-1 flex items-center justify-between text-gray-600">
+        <span>{label}</span>
+        <span className="font-semibold text-gray-800">{pct}%</span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-gray-200">
         <div className="h-full rounded-full bg-indigo-500" style={{ width: `${pct}%` }} />
       </div>
     </div>
   );
 }
 
-/* =================== Utils & Fallbacks =================== */
-function labelSent(s){ const v=(s||'').toLowerCase(); if(['alcista','bullish'].includes(v)) return 'Alcista'; if(['bajista','bearish'].includes(v)) return 'Bajista'; return 'Neutro'; }
-function toneBySent(s){ const v=(s||'').toLowerCase(); if(['alcista','bullish'].includes(v)) return 'success'; if(['bajista','bearish'].includes(v)) return 'danger'; return 'secondary'; }
-function labelImpact(s){ const v=(s||'').toLowerCase(); if(v==='alto'||v==='high') return 'Alto'; if(v==='medio'||v==='medium') return 'Medio'; return 'Bajo'; }
-function toneByImpact(s){ const v=(s||'').toLowerCase(); if(v==='alto'||v==='high') return 'warning'; if(v==='medio'||v==='medium') return 'accent'; return 'secondary'; }
+function useDebouncedValue(value, delay = 250) {
+  const [debounced, setDebounced] = useState(value);
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setDebounced(value);
+    }, delay);
+    return () => clearTimeout(handle);
+  }, [value, delay]);
+  return debounced;
+}
 
-/* Fallbacks visualmente coherentes y de alta disponibilidad */
-const FALLBACKS = [
-  // Fed / tipos / macro
-  'https://images.unsplash.com/photo-1553729459-efe14ef6055d?q=80&w=1600&auto=format&fit=crop',
-  // ETF / mercados
-  'https://images.unsplash.com/photo-1593672715438-d88a70629abe?q=80&w=1600&auto=format&fit=crop',
-  // USD / dólar fuerte
-  'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=1600&auto=format&fit=crop',
-  // Bancos centrales / lingotes
-  'https://images.unsplash.com/photo-1639322537228-f710d846310a?q=80&w=1600&auto=format&fit=crop',
-  // Minería / oferta
-  'https://images.unsplash.com/photo-1566943956303-74261c0f3760?q=80&w=1600&auto=format&fit=crop'
-];
+async function fetchAndAggregate(signal) {
+  const results = await Promise.allSettled([
+    fetchWithBackoff('/api/news?q=gold%20price%20OR%20gold%20market', { signal }),
+    fetchWithBackoff('/.netlify/functions/news-feed', { signal }),
+  ]);
 
+  const items = [];
+  const failures = [];
+
+  const [newsApiRes, openFeedRes] = results;
+
+  if (newsApiRes.status === 'fulfilled' && newsApiRes.value?.items?.length) {
+    for (const item of newsApiRes.value.items) {
+      items.push({ ...item, origin: 'newsapi' });
+    }
+    if (Array.isArray(newsApiRes.value.failures)) failures.push(...newsApiRes.value.failures);
+  } else if (newsApiRes.status === 'rejected') {
+    failures.push({ source: 'newsapi', error: newsApiRes.reason?.message || String(newsApiRes.reason || 'Error NewsAPI') });
+  }
+
+  if (openFeedRes.status === 'fulfilled' && openFeedRes.value?.items?.length) {
+    for (const item of openFeedRes.value.items) {
+      items.push({ ...item, origin: 'open-feed' });
+    }
+    if (Array.isArray(openFeedRes.value.failures)) failures.push(...openFeedRes.value.failures);
+  } else if (openFeedRes.status === 'rejected') {
+    failures.push({ source: 'open-feed', error: openFeedRes.reason?.message || String(openFeedRes.reason || 'Error feed abierto') });
+  }
+
+  return { items, failures };
+}
+
+async function fetchWithBackoff(url, { signal, attempts = MAX_RETRIES + 1, baseDelay = 600 } = {}) {
+  let lastError = null;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    try {
+      const response = await fetchWithTimeout(url, { signal });
+      if (!response) return null;
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const textType = response.headers.get('content-type') || '';
+      if (response.status === 204) return null;
+      if (textType.includes('application/json')) {
+        return await response.json();
+      }
+      const raw = await response.text();
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return raw;
+      }
+    } catch (error) {
+      if (error?.name === 'AbortError') throw error;
+      lastError = error;
+      if (attempt >= attempts - 1) break;
+      const delay = baseDelay * (2 ** attempt);
+      await wait(delay, signal);
+    }
+  }
+  if (lastError) throw lastError;
+  return null;
+}
+
+async function fetchWithTimeout(url, { signal, timeout = FETCH_TIMEOUT_MS, ...options } = {}) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  const cleanup = [];
+  if (signal) {
+    if (signal.aborted) {
+      clearTimeout(timeoutId);
+      throw new DOMException('Aborted', 'AbortError');
+    }
+    const onAbort = () => controller.abort();
+    signal.addEventListener('abort', onAbort, { once: true });
+    cleanup.push(() => signal.removeEventListener('abort', onAbort));
+  }
+  try {
+    const response = await fetch(url, { ...options, signal: controller.signal });
+    return response;
+  } finally {
+    clearTimeout(timeoutId);
+    cleanup.forEach((fn) => fn());
+  }
+}
+
+function wait(ms, signal) {
+  if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+    const cleanup = () => {
+      clearTimeout(timeoutId);
+      if (signal) signal.removeEventListener('abort', onAbort);
+    };
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    if (signal) {
+      if (signal.aborted) {
+        cleanup();
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+async function orchestrateEnrichment(rawItems, signal, imageCache) {
+  if (!Array.isArray(rawItems) || !rawItems.length) return [];
+  const normalized = normalizeAndDedup(rawItems);
+  if (!normalized.length) return [];
+
+  const withSummaries = await runWithConcurrency(
+    normalized,
+    2,
+    async (item) => {
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      const summary = await buildSummary(item);
+      const keywords = extractKeywords(`${item.title || ''} ${summary}`);
+      return {
+        ...item,
+        summaryHint: summary,
+        executiveBrief: summary,
+        keywords,
+      };
+    },
+    signal,
+  );
+
+  const withBias = await runWithConcurrency(
+    withSummaries,
+    2,
+    async (item) => {
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      let biasLabel = 'neutral';
+      let biasScore = 0;
+      try {
+        const result = await classifyBias(`${item.title || ''}. ${item.summaryHint || ''}`);
+        biasLabel = normalizeBiasLabel(result?.label);
+        biasScore = result?.score ?? 0;
+      } catch (error) {
+        console.warn('[GoldNews] Bias classifier fallback', error);
+      }
+      return { ...item, biasLabel, biasScore };
+    },
+    signal,
+  );
+
+  const withSentiment = await runWithConcurrency(
+    withBias,
+    2,
+    async (item) => {
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      let sentimentLabel = 'neutral';
+      let sentimentScore = 0.5;
+      try {
+        const text = `${item.title || ''}. ${item.summaryHint || ''}`.trim();
+        const predictions = await classifySentiment(text || item.title || '');
+        if (Array.isArray(predictions) && predictions[0]) {
+          sentimentLabel = mapSentimentLabel(predictions[0].label);
+          sentimentScore = predictions[0].score ?? sentimentScore;
+        }
+      } catch (error) {
+        console.warn('[GoldNews] FinBERT fallback', error);
+      }
+      return { ...item, sentiment: sentimentLabel, sentimentScore };
+    },
+    signal,
+  );
+
+  const scored = await scoreWithMoE(withSentiment, signal);
+  const withImages = await enrichImages(scored, signal, imageCache);
+
+  return withImages.map((item) => ({
+    ...item,
+    whyMatters: composeWhyMatters(item),
+  }));
+}
+
+function normalizeAndDedup(items) {
+  const map = new Map();
+  for (const raw of items) {
+    const normalized = normalizeArticle(raw);
+    if (!normalized) continue;
+    const key = normalized.dedupKey;
+    const existing = map.get(key);
+    if (!existing) {
+      map.set(key, { ...normalized, stack: [normalized] });
+    } else {
+      existing.stack.push(normalized);
+    }
+  }
+  return Array.from(map.values()).map((entry) => ({ ...entry, stack: entry.stack }));
+}
+
+function normalizeArticle(item) {
+  const title = sanitizeText(item.title) || sanitizeText(item.headline);
+  if (!title) return null;
+  const link = sanitizeText(item.url || item.link || item.permalink);
+  const description = sanitizeText(item.description || item.summary || item.content);
+  const source = sanitizeText(item.source?.name || item.source || item.publisher || 'Fuente anónima');
+  const sourceCategory = sanitizeText(item.sourceCategory || item.category || item.section);
+  const sourceLogo = sanitizeText(item.sourceLogo || item.logo || null);
+  const sourceSite = sanitizeText(item.sourceSite || item.site || null);
+  const imageHint = sanitizeText(item.image || item.imageUrl || item.urlToImage || item.enclosure?.url || item.media?.url);
+  const { ms: publishedAtMs, iso: publishedAtIso } = parsePublishedDate(item.publishedAtIso || item.publishedAt || item.pubDate || item.date);
+  const dedupKey = stableHash(`${title.toLowerCase()}::${formatDomain(link || sourceSite || source)}`);
+
+  return {
+    id: stableHash(`${dedupKey}:${publishedAtMs || ''}`),
+    dedupKey,
+    title,
+    description,
+    content: sanitizeText(item.content),
+    link: link || null,
+    source,
+    sourceCategory,
+    sourceLogo,
+    sourceSite,
+    sourceDomain: formatDomain(link || sourceSite || source),
+    imageHint,
+    publishedAtIso,
+    publishedAtMs,
+    relativeDate: formatRelativeDate(publishedAtMs),
+    origin: item.origin || 'unknown',
+  };
+}
+
+function sanitizeText(value) {
+  if (!value) return '';
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function parsePublishedDate(raw) {
+  if (!raw) return { ms: null, iso: null };
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) return { ms: null, iso: null };
+  const date = new Date(ms);
+  return { ms, iso: date.toISOString() };
+}
+
+function formatRelativeDate(timestamp) {
+  if (!Number.isFinite(timestamp)) return 'Fecha no disponible';
+  const diffMs = Date.now() - timestamp;
+  if (diffMs < 0) return 'Programado para publicar';
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+  if (diffMinutes < 1) return 'Hace instantes';
+  if (diffMinutes < 60) return `Hace ${diffMinutes} minuto${diffMinutes === 1 ? '' : 's'}`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `Hace ${diffHours} hora${diffHours === 1 ? '' : 's'}`;
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 7) return `Hace ${diffDays} día${diffDays === 1 ? '' : 's'}`;
+  const diffWeeks = Math.floor(diffDays / 7);
+  if (diffWeeks < 5) return `Hace ${diffWeeks} semana${diffWeeks === 1 ? '' : 's'}`;
+  const diffMonths = Math.floor(diffDays / 30);
+  return `Hace ${diffMonths} mes${diffMonths === 1 ? '' : 'es'}`;
+}
+
+function stableHash(input) {
+  const str = String(input || '');
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return `n${Math.abs(hash)}`;
+}
+
+function formatDomain(url) {
+  if (!url) return '';
+  try {
+    const parsed = new URL(url.startsWith('http') ? url : `https://${url}`);
+    return parsed.hostname.replace(/^www\./, '');
+  } catch {
+    return url.replace(/^https?:\/\//, '').split('/')[0];
+  }
+}
+
+async function runWithConcurrency(items, limit, task, signal) {
+  if (!items.length) return [];
+  const results = new Array(items.length);
+  const executing = [];
+  for (let index = 0; index < items.length; index += 1) {
+    if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+    const promise = Promise.resolve().then(() => task(items[index], index));
+    results[index] = promise;
+    const wrapped = promise.then(
+      (value) => {
+        const pos = executing.indexOf(wrapped);
+        if (pos >= 0) executing.splice(pos, 1);
+        return value;
+      },
+      (error) => {
+        const pos = executing.indexOf(wrapped);
+        if (pos >= 0) executing.splice(pos, 1);
+        throw error;
+      },
+    );
+    executing.push(wrapped);
+    if (executing.length >= limit) {
+      await Promise.race(executing);
+    }
+  }
+  return Promise.all(results);
+}
+
+async function buildSummary(item) {
+  const baseText = sanitizeText(item.description || item.content);
+  if (!baseText) {
+    return sanitizeText(item.title);
+  }
+  const trimmed = baseText.length > 240 ? `${baseText.slice(0, 240)}…` : baseText;
+  try {
+    const summary = await summarize(trimmed, { maxLength: 120, minLength: 40 });
+    return sanitizeText(summary) || trimmed;
+  } catch (error) {
+    console.warn('[GoldNews] Summarizer fallback', error);
+    return trimmed;
+  }
+}
+
+function normalizeBiasLabel(label) {
+  if (!label) return 'neutral';
+  const value = String(label).toLowerCase();
+  if (value.includes('liberal')) return 'liberal';
+  if (value.includes('conserv')) return 'conservative';
+  if (value.includes('center') || value.includes('centrist')) return 'center';
+  if (value.includes('pro-market') || value.includes('pro market')) return 'pro-market';
+  if (value.includes('anti-market') || value.includes('anti market')) return 'anti-market';
+  return 'neutral';
+}
+
+function mapSentimentLabel(label) {
+  if (!label) return 'neutral';
+  const value = String(label).toLowerCase();
+  if (value.includes('positive') || value.includes('bull')) return 'bullish';
+  if (value.includes('negative') || value.includes('bear')) return 'bearish';
+  return 'neutral';
+}
+
+async function scoreWithMoE(items, signal) {
+  if (!items.length) return [];
+  if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+  const prepared = items.map((item) => ({
+    id: item.id,
+    title: item.title,
+    summaryHint: item.summaryHint,
+    link: item.link,
+    source: item.source,
+    sourceLogo: item.sourceLogo,
+    sourceCategory: item.sourceCategory,
+    publishedAt: item.publishedAtIso || item.publishedAt,
+    publishedAtIso: item.publishedAtIso,
+    publishedAtMs: item.publishedAtMs,
+    imageHint: item.imageHint,
+    description: item.description,
+    stack: item.stack,
+  }));
+  const scored = await scoreNewsItems(prepared);
+  const map = new Map();
+  for (const entry of scored) {
+    const key = entry.id || stableHash(`${entry.title || ''}${entry.link || ''}`);
+    map.set(key, entry);
+  }
+  return items.map((item) => {
+    const scoredItem = map.get(item.id) || {};
+    const experts = Array.isArray(scoredItem.experts) ? scoredItem.experts : [];
+    return {
+      ...item,
+      image: scoredItem.image || item.imageHint,
+      moeInsight: scoredItem.insight || null,
+      impactLevel: scoredItem.impact || 'medio',
+      relevance: scoredItem.relevance ?? item.relevance ?? 0,
+      confidence: scoredItem.confidence ?? item.confidence ?? 0,
+      experts,
+      expertTop: scoredItem.expertTop || experts[0]?.id || '',
+      moeSentiment: scoredItem.sentiment || 'neutro',
+      impactScore: scoredItem.impactScore ?? scoredItem.impact ?? 0,
+      biasLevelModel: scoredItem.bias || 'medio',
+      biasScoreModel: scoredItem.biasScore ?? 0,
+    };
+  });
+}
+
+async function enrichImages(items, signal, cache) {
+  if (!items.length) return items;
+  return runWithConcurrency(
+    items,
+    3,
+    async (item) => {
+      if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
+      const query = buildImageQuery(item);
+      if (!query) return item;
+      const cached = cache.get(query);
+      const now = Date.now();
+      if (cached && cached.expiresAt > now) {
+        return { ...item, image: cached.url || item.image, imageAttribution: cached.credit || item.imageAttribution || null };
+      }
+      try {
+        const response = await fetchWithBackoff(`/api/images?q=${encodeURIComponent(query)}`, { signal, attempts: 1, baseDelay: 400 });
+        const best = Array.isArray(response?.items) ? response.items[0] : null;
+        if (best?.url) {
+          cache.set(query, { url: best.url, credit: best.credit || null, expiresAt: now + CACHE_TTL_MS / 2 });
+          return { ...item, image: best.url, imageAttribution: best.credit || null };
+        }
+      } catch (error) {
+        console.warn('[GoldNews] Unsplash fallback', error);
+      }
+      cache.set(query, { url: item.image, credit: item.imageAttribution || null, expiresAt: now + 60_000 });
+      return item;
+    },
+    signal,
+  );
+}
+
+function buildImageQuery(item) {
+  if (item.keywords?.length) {
+    return `${item.keywords.slice(0, 3).join(' ')} gold`;
+  }
+  if (item.expertTop === 'macro') return 'federal reserve interest rates gold';
+  if (item.expertTop === 'etf') return 'gold etf flows bullion';
+  if (item.expertTop === 'usd') return 'us dollar currency gold';
+  if (item.expertTop === 'cb') return 'central bank gold reserves';
+  return `${item.title || 'gold news'}`;
+}
+
+function postProcessNews(items) {
+  if (!items.length) return { clusters: [], trend: null };
+  const clusters = dedupeSemantic(items).sort((a, b) => {
+    const relevanceDiff = (b.relevance || 0) - (a.relevance || 0);
+    if (relevanceDiff !== 0) return relevanceDiff;
+    const timeDiff = (b.publishedAtMs || 0) - (a.publishedAtMs || 0);
+    if (timeDiff !== 0) return timeDiff;
+    return a.id.localeCompare(b.id);
+  });
+  const trend = computeTrend(items);
+  return { clusters, trend };
+}
+
+function dedupeSemantic(items) {
+  const groups = [];
+  for (const item of items) {
+    const vector = vectorFromExperts(item.experts);
+    let matched = null;
+    for (const group of groups) {
+      const similarity = cosineSimilarity(vector, group.vector);
+      const timeDelta = Math.abs((item.publishedAtMs || 0) - (group.primary.publishedAtMs || 0));
+      if (similarity >= 0.97 && timeDelta <= 1000 * 60 * 240) {
+        matched = group;
+        break;
+      }
+    }
+    if (matched) {
+      matched.members.push(item);
+      matched.vector = matched.vector.map((value, index) => (value + vector[index]) / 2);
+      if ((item.relevance || 0) > (matched.primary.relevance || 0)) {
+        matched.primary = item;
+      }
+      continue;
+    }
+    groups.push({ primary: item, vector, members: [item] });
+  }
+
+  return groups.map((group) => {
+    const stackMap = new Map();
+    for (const member of group.members) {
+      const variations = Array.isArray(member.stack) ? member.stack : [member];
+      for (const variation of variations) {
+        const key = variation.id || stableHash(`${variation.title || ''}${variation.link || ''}`);
+        if (!stackMap.has(key)) {
+          stackMap.set(key, {
+            ...variation,
+            relevance: variation.relevance ?? member.relevance ?? 0,
+            publishedAtMs: variation.publishedAtMs ?? member.publishedAtMs,
+          });
+        }
+      }
+    }
+    const stack = Array.from(stackMap.values()).sort((a, b) => {
+      const relevanceDiff = (b.relevance || 0) - (a.relevance || 0);
+      if (relevanceDiff !== 0) return relevanceDiff;
+      const timeDiff = (b.publishedAtMs || 0) - (a.publishedAtMs || 0);
+      if (timeDiff !== 0) return timeDiff;
+      return (a.id || '').localeCompare(b.id || '');
+    });
+    const primary = group.primary;
+    return {
+      ...primary,
+      stack,
+      stackSize: stack.length,
+    };
+  });
+}
+
+function vectorFromExperts(experts = []) {
+  const vector = EXPERT_ORDER.map(() => 0);
+  for (const expert of experts) {
+    const index = EXPERT_ORDER.indexOf(expert.id);
+    if (index >= 0) {
+      vector[index] = expert.cos ?? expert.alpha ?? 0;
+    }
+  }
+  return vector;
+}
+
+function cosineSimilarity(a, b) {
+  if (!a.length || !b.length) return 0;
+  let dot = 0;
+  let normA = 0;
+  let normB = 0;
+  for (let i = 0; i < Math.min(a.length, b.length); i += 1) {
+    dot += a[i] * b[i];
+    normA += a[i] * a[i];
+    normB += b[i] * b[i];
+  }
+  if (!normA || !normB) return 0;
+  return dot / (Math.sqrt(normA) * Math.sqrt(normB));
+}
+
+function computeTrend(items) {
+  if (!items.length) return null;
+  const totals = { macro: 0, etf: 0, usd: 0, cb: 0 };
+  items.forEach((item) => {
+    const relevanceWeight = (item.relevance || 0.4) + (item.confidence || 0.2);
+    (item.experts || []).forEach((expert) => {
+      if (totals[expert.id] !== undefined) {
+        totals[expert.id] += (expert.alpha || 0) * relevanceWeight;
+      }
+    });
+  });
+  const entries = EXPERT_ORDER.map((id) => ({ id, label: labelForExpert(id), weight: totals[id] || 0 }));
+  const totalWeight = entries.reduce((sum, entry) => sum + entry.weight, 0);
+  if (totalWeight <= 0) return null;
+  const sorted = entries.filter((entry) => entry.weight > 0).sort((a, b) => b.weight - a.weight);
+  const microParts = [];
+  if (sorted[0]) microParts.push(`Predomina ${sorted[0].label} (${Math.round((sorted[0].weight / totalWeight) * 100)}%)`);
+  if (sorted[1]) microParts.push(`seguido por ${sorted[1].label} (${Math.round((sorted[1].weight / totalWeight) * 100)}%)`);
+  const keywordsSet = new Set();
+  items.slice(0, 8).forEach((item) => {
+    (item.keywords || []).slice(0, 2).forEach((keyword) => keywordsSet.add(keyword));
+  });
+  const sequenceBase = items
+    .slice()
+    .sort((a, b) => (a.publishedAtMs || 0) - (b.publishedAtMs || 0))
+    .map((item, index) => {
+      const top = (item.experts || [])[0];
+      const share = Math.max(0.02, top?.alpha || 0.25);
+      const id = top?.id || 'mix';
+      return {
+        key: `${index}-${id}`,
+        label: labelForExpert(id),
+        share,
+        background: colorForExpert(id),
+      };
+    });
+  const totalShare = sequenceBase.reduce((sum, segment) => sum + segment.share, 0) || 1;
+  const sequence = sequenceBase.map((segment) => ({
+    ...segment,
+    share: segment.share / totalShare,
+  }));
+
+  return {
+    microCopy: microParts.join(' · ') || 'Señal mixta entre expertos.',
+    keywords: Array.from(keywordsSet),
+    sequence,
+  };
+}
+
+function labelForExpert(id) {
+  switch (id) {
+    case 'macro':
+      return 'Macro / Fed';
+    case 'etf':
+      return 'ETF / Flujos';
+    case 'usd':
+      return 'USD / FX';
+    case 'cb':
+      return 'Bancos centrales';
+    default:
+      return 'Mixto';
+  }
+}
+
+function colorForExpert(id) {
+  return EXPERT_COLORS[id] || EXPERT_COLORS.mix;
+}
+
+function calcConfidenceAlpha(confidence = 0.5, sentimentScore = 0.5) {
+  const base = Number.isFinite(confidence) ? confidence : 0.5;
+  const tone = Number.isFinite(sentimentScore) ? sentimentScore : 0.5;
+  const weighted = 0.45 + 0.4 * base + 0.25 * tone;
+  return Math.min(1, Math.max(0.45, weighted));
+}
+
+function labelSent(value) {
+  if (value === 'all') return 'Todos';
+  if (value === 'bullish' || value === 'alcista') return 'Alcista';
+  if (value === 'bearish' || value === 'bajista') return 'Bajista';
+  return 'Neutral';
+}
+
+function toneBySent(value) {
+  if (value === 'bullish' || value === 'alcista') return 'success';
+  if (value === 'bearish' || value === 'bajista') return 'danger';
+  return 'secondary';
+}
+
+function labelBias(value) {
+  switch (value) {
+    case 'liberal':
+      return 'Liberal';
+    case 'conservative':
+      return 'Conservador';
+    case 'center':
+      return 'Centro';
+    case 'pro-market':
+      return 'Pro mercado';
+    case 'anti-market':
+      return 'Anti mercado';
+    default:
+      return 'Neutral';
+  }
+}
+
+function labelImpact(value) {
+  if (value === 'alto' || value === 'high') return 'Alto';
+  if (value === 'medio' || value === 'medium') return 'Medio';
+  return 'Bajo';
+}
+
+function toneByImpact(value) {
+  if (value === 'alto' || value === 'high') return 'warning';
+  if (value === 'medio' || value === 'medium') return 'accent';
+  return 'secondary';
+}
+
+function composeWhyMatters(item) {
+  const parts = [];
+  if (item.moeInsight?.effect) parts.push(item.moeInsight.effect);
+  if (item.keywords?.length) parts.push(`Claves: ${item.keywords.slice(0, 5).join(', ')}`);
+  if (item.executiveBrief && parts.length > 0) parts.push(item.executiveBrief);
+  return parts.join(' · ');
+}
+
+const KEYWORD_STOPWORDS = new Set([
+  'the', 'and', 'for', 'that', 'with', 'from', 'this', 'have', 'will', 'into',
+  'las', 'los', 'una', 'unos', 'unas', 'del', 'por', 'para', 'sobre', 'como',
+  'cuando', 'ante', 'donde', 'entre', 'hacia', 'hace', 'pero', 'tras', 'cada',
+  'gold', 'oro', 'price', 'prices', 'market', 'news', 'latest', 'update',
+]);
+
+function extractKeywords(text) {
+  if (!text) return [];
+  const words = text
+    .toLowerCase()
+    .split(/[^a-záéíóúñ0-9]+/)
+    .filter((word) => word && word.length > 3 && !KEYWORD_STOPWORDS.has(word));
+  if (!words.length) return [];
+  const frequency = new Map();
+  for (const word of words) frequency.set(word, (frequency.get(word) || 0) + 1);
+  return Array.from(frequency.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8)
+    .map(([word]) => word);
+}

--- a/src/utils/finSentiment.js
+++ b/src/utils/finSentiment.js
@@ -5,9 +5,16 @@
  * (Licencia MIT para el modelo FinBERT).
  */
 
-import * as transformers from '@xenova/transformers';
-
 let classifierPromise = null;
+let transformersPromise = null;
+
+async function loadTransformers() {
+  if (!transformersPromise) {
+    transformersPromise = import('@xenova/transformers')
+      .then((mod) => (mod && mod.pipeline ? mod : mod?.default || mod));
+  }
+  return transformersPromise;
+}
 
 /**
  * Obtiene o crea el clasificador FinBERT.
@@ -15,6 +22,7 @@ let classifierPromise = null;
 async function getClassifier() {
   if (!classifierPromise) {
     classifierPromise = (async () => {
+      const transformers = await loadTransformers();
       try {
         const pipeline = await transformers.pipeline('text-classification', 'ProsusAI/finbert');
         return pipeline;


### PR DESCRIPTION
## Summary
- Rebuilt `GoldNewsGlassCarousel` around the full Klever Orion v2.0 pipeline, orchestrating secure fetch, summarisation, bias & sentiment inference, MoE scoring, image enrichment and deterministic virtualization with accessibility-first glassmorphism UI.
- Added interactive intelligence controls (impact/bias filters, search debounce, sort, trend banner and expert stacks) plus resilient caching, circuit breaking, idle prefetch and insight modal extensions that surface “por qué importa” narratives from existing signals.
- Exposed secure Express proxies for NewsAPI and Unsplash with sanitisation, backoff, coalesced caching and cache-control headers so secrets remain server-side while the carousel performs SWR image/news refreshes.
- Inlined an accessible `EmailSignupDialog` within `FloatingMenu` so the build succeeds without referencing a missing module while preserving the polished signup UX.
- Lazy-loaded `@xenova/transformers` inside the FinBERT utility so the bundle resolves the dependency correctly in static Netlify builds while preserving classifier fallbacks.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d182f79c98832d93b82d57a3baceff