### PR TITLE
Secure external API keys via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,12 @@ por:
 ## Nota Netlify / Vite
 Si más adelante añades `package-lock.json`, puedes volver a `npm ci && npm run build` en `netlify.toml`.
 Asegúrate de tener `public/config.js` presente para que `<script src="/config.js" defer></script>` lo sirva estáticamente.
+
+## Variables de entorno necesarias
+
+El backend Express y los helpers de `src/utils` ya no incluyen claves embebidas para los servicios externos. Antes de ejecutar el servidor local (`npm run dev` en `server`) o desplegar en plataformas como Render/Netlify, define estas variables de entorno:
+
+- `NEWS_API_KEY`: clave de [NewsAPI](https://newsapi.org/) para obtener titulares relacionados con el oro.
+- `UNSPLASH_ACCESS_KEY`: clave pública de [Unsplash](https://unsplash.com/developers) para buscar imágenes.
+
+Los archivos de ejemplo `.env` (`env.builds`, `env.functions`) incluyen las variables vacías para que añadas los valores correctos en tu entorno seguro. Si alguna de estas claves falta en tiempo de ejecución, las rutas `/api/news` y `/api/images` responderán con un HTTP 502 indicando que el servicio no está configurado.

--- a/env.builds
+++ b/env.builds
@@ -14,8 +14,10 @@ VITE_CSV_URL=/data/xauusd_ohlc_clean.csv
 
 
 # --- API Keys ---
-FRED_API_KEY=61d85317a35efea7d8db6684ff3048a3
-NEWS_API_KEY=b7376a8668cf442585efad67279e57a4
-UNSPLASH_APP_ID=807593
-UNSPLASH_ACCESS_KEY=dDRMnni-JMRIvgxiQl9vzOwm1fkVUfU5atwljm3vK7c
-UNSPLASH_SECRET_KEY=hABGzW__LJHjBmndrWI1ub6EyZ3qGfRwfqJYZ_rPM-E
+# Configura estas variables en tu plataforma de despliegue (Render/Netlify) o en tu entorno local
+# antes de arrancar el servidor. No se incluyen valores por defecto para evitar exponer credenciales.
+FRED_API_KEY=
+NEWS_API_KEY=
+UNSPLASH_APP_ID=
+UNSPLASH_ACCESS_KEY=
+UNSPLASH_SECRET_KEY=

--- a/env.functions
+++ b/env.functions
@@ -16,9 +16,9 @@ CSV_PATH=public/data/xauusd_ohlc_clean.csv
 CSV_BRANCH=main
 
 
-# API Keys for external services
-FRED_API_KEY=61d85317a35efea7d8db6684ff3048a3
-NEWS_API_KEY=b7376a8668cf442585efad67279e57a4
-UNSPLASH_APP_ID=807593
-UNSPLASH_ACCESS_KEY=dDRMnni-JMRIvgxiQl9vzOwm1fkVUfU5atwljm3vK7c
-UNSPLASH_SECRET_KEY=hABGzW__LJHjBmndrWI1ub6EyZ3qGfRwfqJYZ_rPM-E
+# API Keys for external services (deben proporcionarse como variables de entorno seguras)
+FRED_API_KEY=
+NEWS_API_KEY=
+UNSPLASH_APP_ID=
+UNSPLASH_ACCESS_KEY=
+UNSPLASH_SECRET_KEY=

--- a/server/index.js
+++ b/server/index.js
@@ -192,6 +192,12 @@ app.use(express.json());
  */
 app.get('/api/news', async (req, res) => {
   const query = sanitizeQuery(req.query?.q, 'gold price OR gold market');
+  if (!process.env.NEWS_API_KEY) {
+    newsProxyCache.payload = null;
+    newsProxyCache.expiresAt = 0;
+    newsProxyCache.promise = null;
+    return res.status(502).json({ ok: false, error: 'Servicio de noticias no configurado' });
+  }
   res.set('Cache-Control', 'public, max-age=120, stale-while-revalidate=300');
   const now = Date.now();
   if (newsProxyCache.payload && newsProxyCache.key === query && newsProxyCache.expiresAt > now) {
@@ -238,6 +244,10 @@ app.get('/api/images', async (req, res) => {
   const query = sanitizeQuery(req.query?.q, 'gold bullion');
   if (!query) {
     return res.status(400).json({ ok: false, error: 'Consulta vacía' });
+  }
+  if (!process.env.UNSPLASH_ACCESS_KEY) {
+    imageProxyCache.clear();
+    return res.status(502).json({ ok: false, error: 'Servicio de imágenes no configurado' });
   }
   res.set('Cache-Control', 'public, max-age=300, stale-while-revalidate=600');
   let entry = imageProxyCache.get(query);

--- a/src/utils/newsApi.js
+++ b/src/utils/newsApi.js
@@ -1,7 +1,14 @@
 import fetch from 'node-fetch';
 
-const API_KEY = process.env.NEWS_API_KEY || 'b7376a8668cf442585efad67279e57a4';
 const NEWS_ENDPOINT = 'https://newsapi.org/v2/everything';
+
+function resolveNewsApiKey() {
+  const apiKey = process.env.NEWS_API_KEY;
+  if (!apiKey) {
+    throw new Error('NEWS_API_KEY environment variable is not set');
+  }
+  return apiKey;
+}
 
 /**
  * Fetches recent gold‑related news articles from the NewsAPI.
@@ -11,12 +18,13 @@ const NEWS_ENDPOINT = 'https://newsapi.org/v2/everything';
  * @returns {Promise<Array>} - A promise that resolves to an array of article objects.
  */
 export async function fetchGoldNews(query = 'gold price OR gold market', pageSize = 20) {
+  const apiKey = resolveNewsApiKey();
   const params = new URLSearchParams({
     q: query,
     sortBy: 'publishedAt',
     language: 'en',
     pageSize: String(pageSize),
-    apiKey: API_KEY
+    apiKey
   });
   const url = `${NEWS_ENDPOINT}?${params.toString()}`;
   const response = await fetch(url);

--- a/src/utils/unsplash.js
+++ b/src/utils/unsplash.js
@@ -1,5 +1,12 @@
-const ACCESS_KEY = process.env.UNSPLASH_ACCESS_KEY || 'dDRMnni-JMRIvgxiQl9vzOwm1fkVUfU5atwljm3vK7c';
 const UNSPLASH_ENDPOINT = 'https://api.unsplash.com/search/photos';
+
+function resolveUnsplashAccessKey() {
+  const accessKey = process.env.UNSPLASH_ACCESS_KEY;
+  if (!accessKey) {
+    throw new Error('UNSPLASH_ACCESS_KEY environment variable is not set');
+  }
+  return accessKey;
+}
 
 /**
  * Searches Unsplash for images related to the given query. Returns a list of image metadata.
@@ -9,10 +16,11 @@ const UNSPLASH_ENDPOINT = 'https://api.unsplash.com/search/photos';
  * @returns {Promise<Array>} - A promise that resolves to an array of image objects with URL and metadata.
  */
 export async function searchUnsplashImages(query = 'gold bullion', perPage = 3) {
+  const accessKey = resolveUnsplashAccessKey();
   const params = new URLSearchParams({
     query,
     per_page: String(perPage),
-    client_id: ACCESS_KEY
+    client_id: accessKey
   });
   const url = `${UNSPLASH_ENDPOINT}?${params.toString()}`;
   const response = await fetch(url);


### PR DESCRIPTION
## Summary
- remove hard-coded NewsAPI and Unsplash keys from the utility helpers and throw clear errors when variables are absent
- guard Express proxies to return a controlled 502 when credentials are missing and avoid caching stale data
- update environment samples and documentation to require configuring API keys via environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ab56b03c832d9164c4d7f7476b6f