### PR TITLE
Use runtime fetch for NewsAPI

### DIFF
--- a/src/utils/newsApi.js
+++ b/src/utils/newsApi.js
@@ -1,7 +1,18 @@
-import fetch from 'node-fetch';
-
 const API_KEY = process.env.NEWS_API_KEY || 'b7376a8668cf442585efad67279e57a4';
 const NEWS_ENDPOINT = 'https://newsapi.org/v2/everything';
+
+let cachedFetch = null;
+
+async function getFetch() {
+  if (cachedFetch) return cachedFetch;
+  if (typeof globalThis.fetch === 'function') {
+    cachedFetch = globalThis.fetch.bind(globalThis);
+    return cachedFetch;
+  }
+  const { default: polyfill } = await import('node-fetch');
+  cachedFetch = polyfill;
+  return cachedFetch;
+}
 
 /**
  * Fetches recent gold‑related news articles from the NewsAPI.
@@ -19,11 +30,31 @@ export async function fetchGoldNews(query = 'gold price OR gold market', pageSiz
     apiKey: API_KEY
   });
   const url = `${NEWS_ENDPOINT}?${params.toString()}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    throw new Error(`NewsAPI error: ${response.status}`);
+  const fetchFn = await getFetch();
+
+  let response;
+  try {
+    response = await fetchFn(url);
+  } catch (error) {
+    const detail = error?.message || 'Network request failed';
+    throw new Error(`NewsAPI request error: ${detail}`);
   }
-  const data = await response.json();
+
+  let data;
+  try {
+    data = await response.json();
+  } catch (error) {
+    if (!response.ok) {
+      const detail = error?.message || response.statusText || 'Unknown error';
+      throw new Error(`NewsAPI error: ${response.status} (${detail})`);
+    }
+    throw new Error('NewsAPI returned invalid JSON');
+  }
+
+  if (!response.ok) {
+    const detail = data?.message || data?.error || response.statusText || 'Unknown error';
+    throw new Error(`NewsAPI error: ${response.status} (${detail})`);
+  }
   return (data.articles || []).map((article) => ({
     title: article.title,
     description: article.description,


### PR DESCRIPTION
## Summary
- remove the direct dependency on `node-fetch` and rely on the runtime-provided `fetch`
- lazily load a polyfill only when `globalThis.fetch` is unavailable
- harden NewsAPI error handling so the proxy can return clearer diagnostics

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ab576e38832d8d6f4c91ad43d694