### PR TITLE
Auto-fill missing OHLC gaps after CSV load

### DIFF
--- a/src/components/GoldNowSection.jsx
+++ b/src/components/GoldNowSection.jsx
@@ -2,7 +2,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 'use client';
 
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState, useCallback, useRef } from 'react';
 import {
   ResponsiveContainer,
   AreaChart,
@@ -113,6 +113,9 @@ export default function GoldNowSection({ rows = [], onAppendRows, fetchMissingDa
     return days;
   }, [lastCsvDate, yesterday, iso]);
 
+  const gapsSignature = useMemo(() => gapsToYesterday.join('|'), [gapsToYesterday]);
+  const autoFillRef = useRef('');
+
   // Puede el padre pedir los días faltantes
   const canFetch = typeof fetchMissingDaysSequential === 'function';
 
@@ -166,6 +169,14 @@ export default function GoldNowSection({ rows = [], onAppendRows, fetchMissingDa
   useEffect(() => {
     updateNow();
   }, []);
+
+  useEffect(() => {
+    if (!canFetch) return;
+    if (!gapsSignature) return;
+    if (autoFillRef.current === gapsSignature) return;
+    autoFillRef.current = gapsSignature;
+    updateNow();
+  }, [canFetch, gapsSignature, updateNow]);
 
   // Polling para refrescar sólo el spot cada 60 segundos
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure GoldNowSection can automatically request missing OHLC days once the base CSV finishes loading
- memoize a gaps signature and track last auto-filled batch to avoid redundant fetches while keeping the existing UI intact

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b2fa2f64832d9f404e5bb1014453