### PR TITLE
Stabilize external news and image proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,12 @@ por:
 ## Nota Netlify / Vite
 Si más adelante añades `package-lock.json`, puedes volver a `npm ci && npm run build` en `netlify.toml`.
 Asegúrate de tener `public/config.js` presente para que `<script src="/config.js" defer></script>` lo sirva estáticamente.
+
+## Variables de entorno necesarias
+
+El backend Express y los helpers de `src/utils` ya no incluyen claves embebidas para los servicios externos. Antes de ejecutar el servidor local (`npm run dev` en `server`) o desplegar en plataformas como Render/Netlify, define estas variables de entorno:
+
+- `NEWS_API_KEY`: clave de [NewsAPI](https://newsapi.org/) para obtener titulares relacionados con el oro.
+- `UNSPLASH_ACCESS_KEY`: clave pública de [Unsplash](https://unsplash.com/developers) para buscar imágenes.
+
+Los archivos de ejemplo `.env` (`env.builds`, `env.functions`) incluyen las variables vacías para que añadas los valores correctos en tu entorno seguro. Si alguna de estas claves falta en tiempo de ejecución, las rutas `/api/news` y `/api/images` responderán con un HTTP 502 indicando que el servicio no está configurado.

--- a/env.builds
+++ b/env.builds
@@ -14,8 +14,10 @@ VITE_CSV_URL=/data/xauusd_ohlc_clean.csv
 
 
 # --- API Keys ---
-FRED_API_KEY=61d85317a35efea7d8db6684ff3048a3
-NEWS_API_KEY=b7376a8668cf442585efad67279e57a4
-UNSPLASH_APP_ID=807593
-UNSPLASH_ACCESS_KEY=dDRMnni-JMRIvgxiQl9vzOwm1fkVUfU5atwljm3vK7c
-UNSPLASH_SECRET_KEY=hABGzW__LJHjBmndrWI1ub6EyZ3qGfRwfqJYZ_rPM-E
+# Configura estas variables en tu plataforma de despliegue (Render/Netlify) o en tu entorno local
+# antes de arrancar el servidor. No se incluyen valores por defecto para evitar exponer credenciales.
+FRED_API_KEY=
+NEWS_API_KEY=
+UNSPLASH_APP_ID=
+UNSPLASH_ACCESS_KEY=
+UNSPLASH_SECRET_KEY=

--- a/env.functions
+++ b/env.functions
@@ -16,9 +16,9 @@ CSV_PATH=public/data/xauusd_ohlc_clean.csv
 CSV_BRANCH=main
 
 
-# API Keys for external services
-FRED_API_KEY=61d85317a35efea7d8db6684ff3048a3
-NEWS_API_KEY=b7376a8668cf442585efad67279e57a4
-UNSPLASH_APP_ID=807593
-UNSPLASH_ACCESS_KEY=dDRMnni-JMRIvgxiQl9vzOwm1fkVUfU5atwljm3vK7c
-UNSPLASH_SECRET_KEY=hABGzW__LJHjBmndrWI1ub6EyZ3qGfRwfqJYZ_rPM-E
+# API Keys for external services (deben proporcionarse como variables de entorno seguras)
+FRED_API_KEY=
+NEWS_API_KEY=
+UNSPLASH_APP_ID=
+UNSPLASH_ACCESS_KEY=
+UNSPLASH_SECRET_KEY=

--- a/src/utils/newsApi.js
+++ b/src/utils/newsApi.js
@@ -1,7 +1,27 @@
-import fetch from 'node-fetch';
-
-const API_KEY = process.env.NEWS_API_KEY || 'b7376a8668cf442585efad67279e57a4';
 const NEWS_ENDPOINT = 'https://newsapi.org/v2/everything';
+
+let fetchModulePromise;
+
+function resolveFetch() {
+  if (typeof fetch === 'function') return fetch;
+  if (!fetchModulePromise) {
+    fetchModulePromise = import('node-fetch').then((mod) => mod.default || mod);
+  }
+  return fetchModulePromise;
+}
+
+async function httpFetch(url, options) {
+  const impl = await resolveFetch();
+  return impl(url, options);
+}
+
+function resolveNewsApiKey() {
+  const apiKey = process.env.NEWS_API_KEY;
+  if (!apiKey) {
+    throw new Error('NEWS_API_KEY environment variable is not set');
+  }
+  return apiKey;
+}
 
 /**
  * Fetches recent gold‑related news articles from the NewsAPI.
@@ -11,15 +31,16 @@ const NEWS_ENDPOINT = 'https://newsapi.org/v2/everything';
  * @returns {Promise<Array>} - A promise that resolves to an array of article objects.
  */
 export async function fetchGoldNews(query = 'gold price OR gold market', pageSize = 20) {
+  const apiKey = resolveNewsApiKey();
   const params = new URLSearchParams({
     q: query,
     sortBy: 'publishedAt',
     language: 'en',
     pageSize: String(pageSize),
-    apiKey: API_KEY
+    apiKey,
   });
   const url = `${NEWS_ENDPOINT}?${params.toString()}`;
-  const response = await fetch(url);
+  const response = await httpFetch(url);
   if (!response.ok) {
     throw new Error(`NewsAPI error: ${response.status}`);
   }


### PR DESCRIPTION
## Summary
- use a runtime fetch resolver so the NewsAPI and Unsplash helpers work without a hard dependency on node-fetch
- let the Express proxies serve cached payloads when upstream APIs hiccup while still surfacing a detail string
- keep returning 502 responses only when no cached data exists, preventing transient incidents from bubbling back to the UI

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1ab56b03c832d9164c4d7f7476b6f