### PR TITLE
Align news carousel with backend base URL

### DIFF
--- a/netlify/functions/news-feed.js
+++ b/netlify/functions/news-feed.js
@@ -167,7 +167,7 @@ exports.handler = async (event) => {
 
   if (!aggregated.length) {
     //return H.json(502, { ok: false, error: 'Sin datos disponibles', failures });
-        return H.json(200, { items: [] });
+    return H.json(200, { items: [], failures });
   }
 
   const map = new Map();
@@ -186,7 +186,7 @@ exports.handler = async (event) => {
     .slice(0, 60);
 
   //return H.json(200, { ok: true, items: list, failures });
-      return H.json(200, { items: list });
+  return H.json(200, { items: list, failures });
 };
 
 function normalizeItems(doc, src) {


### PR DESCRIPTION
## Summary
- resolve NewsAPI requests in the gold news carousel through the configured backend base URL when provided
- include failure metadata in the Netlify news-feed function responses for easier diagnostics when sources are unavailable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d420324f54832d9ccfcdbad767678f