### PR TITLE
Improve news sentiment and unique imagery

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -261,8 +261,8 @@ app.get('/api/images', async (req, res) => {
   }
   if (!entry.promise) {
     entry.promise = (async () => {
-      const images = await searchUnsplashImages(query, 4);
-      const items = (images || []).slice(0, 4).map((image) => ({
+      const images = await searchUnsplashImages(query, 8);
+      const items = (images || []).slice(0, 8).map((image) => ({
         url: sanitizeUrl(image.url),
         thumbnail: sanitizeUrl(image.thumbnail),
         alt: sanitizeString(image.alt),

--- a/src/components/GoldNewsGlassCarousel.jsx
+++ b/src/components/GoldNewsGlassCarousel.jsx
@@ -25,7 +25,7 @@ import {
 import { scoreNewsItems } from '../utils/newsMoE.js';
 import { summarize } from '../utils/newsSummarizer.js';
 import { classifyBias } from '../utils/newsBias.js';
-import { classifySentiment } from '../utils/finSentiment.js';
+import { classifySentiment, resolveSentiment } from '../utils/finSentiment.js';
 
 const CACHE_KEY = 'klever_orion_v2_news_cache';
 const CACHE_TTL_MS = 10 * 60 * 1000;
@@ -44,6 +44,11 @@ const FALLBACK_IMAGES = [
   'https://images.unsplash.com/photo-1554224155-6726b3ff858f?q=80&w=1600&auto=format&fit=crop',
   'https://images.unsplash.com/photo-1639322537228-f710d846310a?q=80&w=1600&auto=format&fit=crop',
   'https://images.unsplash.com/photo-1566943956303-74261c0f3760?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1450101499163-c8848c66ca85?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1530172991371-4b50ab9746c7?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1586165368502-1bad197a6461?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1579722821273-0fdd166a8c8b?q=80&w=1600&auto=format&fit=crop',
+  'https://images.unsplash.com/photo-1580657018950-4480b9360c7e?q=80&w=1600&auto=format&fit=crop',
 ];
 const EXPERT_ORDER = ['macro', 'etf', 'usd', 'cb'];
 const EXPERT_COLORS = {
@@ -52,6 +57,13 @@ const EXPERT_COLORS = {
   usd: '#0EA5E9',
   cb: '#F97316',
   mix: '#94A3B8',
+};
+const CANONICAL_SOURCE_LABELS = {
+  newsapi: 'NewsAPI',
+  'open-feed': 'Feed abierto',
+  'open feed': 'Feed abierto',
+  'u.s. treasury': 'U.S. Treasury',
+  'us treasury': 'U.S. Treasury',
 };
 
 export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
@@ -68,10 +80,14 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
   const [active, setActive] = useState(initialIndex);
 
   const wrapRef = useRef(null);
+  const activeRef = useRef(initialIndex);
   const pipelineRef = useRef({ promise: null, controller: null, failureCount: 0, openUntil: 0 });
   const cacheRef = useRef(null);
   const imageCacheRef = useRef(new Map());
   const firstLoad = useRef(false);
+  const scrollReleaseRef = useRef(null);
+  const scrollFrameRef = useRef(null);
+  const programmaticScrollRef = useRef(false);
   const debouncedSearch = useDebouncedValue(searchTerm, 240);
 
   const hasData = news.length > 0;
@@ -115,20 +131,24 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
     return sorted;
   }, [news, filters, debouncedSearch, sortBy]);
 
-  const virtualizationWindow = useMemo(() => {
-    const size = filteredItems.length;
-    if (!size) return new Set();
-    const windowRadius = 4;
-    const start = Math.max(0, active - windowRadius);
-    const end = Math.min(size - 1, active + windowRadius);
-    const set = new Set();
-    for (let i = start; i <= end; i += 1) set.add(i);
-    return set;
-  }, [filteredItems.length, active]);
-
   const cardsToRender = isLoading && !hasData
     ? Array.from({ length: 6 }, (_, index) => ({ __skeleton: true, id: `skeleton-${index}` }))
     : filteredItems;
+
+  const failureSources = useMemo(() => {
+    if (!failures.length) return [];
+    const seen = new Set();
+    const list = [];
+    for (const entry of failures) {
+      const rawName = sanitizeText(entry?.name || entry?.source);
+      if (!rawName) continue;
+      const key = rawName.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      list.push(prettySourceLabel(rawName));
+    }
+    return list;
+  }, [failures]);
 
   const loadFromCache = useCallback(() => {
     if (cacheRef.current) return cacheRef.current;
@@ -245,50 +265,107 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
   }, [items, fetchNews, loadFromCache]);
 
   useEffect(() => {
-    const el = wrapRef.current;
-    if (!el || !filteredItems.length) return;
-    const card = el.querySelector('[data-card]');
-    if (!card) return;
-    const gap = 24;
-    const width = card.getBoundingClientRect().width;
-    const idx = active < filteredItems.length ? active : 0;
-    const left = Math.max(0, idx * (width + gap) - (el.clientWidth - width) / 2);
-    el.scrollTo({ left, behavior: 'smooth' });
-  }, [filteredItems.length, active]);
+    activeRef.current = active;
+  }, [active]);
+
+  const focusCard = useCallback(
+    (index, { smooth = true } = {}) => {
+      if (typeof window === 'undefined') return;
+      const el = wrapRef.current;
+      if (!el) return;
+      const target = el.querySelector(`[data-card][data-idx="${index}"]`);
+      if (!target) return;
+
+      const cardWidth = target.getBoundingClientRect().width;
+      const offset = target.offsetLeft;
+      const left = Math.max(0, offset - Math.max(0, (el.clientWidth - cardWidth) / 2));
+
+      programmaticScrollRef.current = true;
+      if (scrollReleaseRef.current) {
+        clearTimeout(scrollReleaseRef.current);
+      }
+
+      el.scrollTo({ left, behavior: smooth ? 'smooth' : 'auto' });
+      scrollReleaseRef.current = setTimeout(() => {
+        programmaticScrollRef.current = false;
+      }, smooth ? 420 : 80);
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!filteredItems.length) {
+      activeRef.current = 0;
+      setActive(0);
+      return;
+    }
+    const clamped = Math.min(activeRef.current, filteredItems.length - 1);
+    activeRef.current = clamped;
+    setActive(clamped);
+    focusCard(clamped, { smooth: false });
+  }, [filteredItems.length, focusCard]);
 
   useEffect(() => {
     const el = wrapRef.current;
     if (!el) return;
-    if (!filteredItems.length) return;
 
-    const io = new IntersectionObserver(
-      (entries) => {
-        const vis = entries
-          .filter((entry) => entry.isIntersecting)
-          .map((entry) => ({ idx: Number(entry.target.getAttribute('data-idx')), ratio: entry.intersectionRatio }))
-          .sort((a, b) => b.ratio - a.ratio);
-        if (vis[0]) setActive(vis[0].idx);
-      },
-      { root: el, threshold: [0.55, 0.75, 0.95] },
-    );
+    const handleScroll = () => {
+      if (programmaticScrollRef.current) return;
+      if (scrollFrameRef.current) {
+        cancelAnimationFrame(scrollFrameRef.current);
+      }
+      scrollFrameRef.current = requestAnimationFrame(() => {
+        const card = el.querySelector('[data-card]');
+        if (!card || !filteredItems.length) return;
+        const style = window.getComputedStyle(el);
+        const gap = parseFloat(style.columnGap || style.gap || '24') || 24;
+        const width = card.getBoundingClientRect().width;
+        const approx = Math.round(el.scrollLeft / (width + gap));
+        const clamped = Math.max(0, Math.min(approx, filteredItems.length - 1));
+        if (clamped !== activeRef.current) {
+          activeRef.current = clamped;
+          setActive(clamped);
+        }
+      });
+    };
 
-    const nodes = el.querySelectorAll('[data-card]');
-    nodes.forEach((node) => io.observe(node));
-    return () => io.disconnect();
-  }, [filteredItems]);
+    el.addEventListener('scroll', handleScroll, { passive: true });
+    return () => {
+      el.removeEventListener('scroll', handleScroll);
+      if (scrollFrameRef.current) {
+        cancelAnimationFrame(scrollFrameRef.current);
+        scrollFrameRef.current = null;
+      }
+    };
+  }, [filteredItems.length]);
+
+  useEffect(() => () => {
+    if (scrollReleaseRef.current) {
+      clearTimeout(scrollReleaseRef.current);
+    }
+    if (scrollFrameRef.current) {
+      cancelAnimationFrame(scrollFrameRef.current);
+    }
+  }, []);
 
   useEffect(() => () => {
     pipelineRef.current.controller?.abort();
   }, []);
 
-  const scrollByCards = useCallback((dir = 1) => {
-    const el = wrapRef.current;
-    if (!el) return;
-    const card = el.querySelector('[data-card]');
-    const gap = 24;
-    const width = card ? card.getBoundingClientRect().width : 340;
-    el.scrollBy({ left: dir * (width + gap), behavior: 'smooth' });
-  }, []);
+  const scrollByCards = useCallback(
+    (dir = 1) => {
+      if (!filteredItems.length) return;
+      setActive((prev) => {
+        const next = Math.max(0, Math.min(prev + dir, filteredItems.length - 1));
+        activeRef.current = next;
+        if (next !== prev) {
+          focusCard(next);
+        }
+        return next;
+      });
+    },
+    [filteredItems.length, focusCard],
+  );
 
   const onSelectItem = useCallback((item) => {
     setSelected(item);
@@ -298,24 +375,49 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
     setSelected(null);
   }, []);
 
-  const updateSentimentFilter = useCallback((value) => {
-    setFilters((prev) => ({ ...prev, sentiment: value }));
+  const resetToFirstCard = useCallback(() => {
+    activeRef.current = 0;
     setActive(0);
-  }, []);
+    if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+      window.requestAnimationFrame(() => {
+        focusCard(0, { smooth: false });
+      });
+    } else {
+      focusCard(0, { smooth: false });
+    }
+  }, [focusCard]);
 
-  const updateBiasFilter = useCallback((value) => {
-    setFilters((prev) => ({ ...prev, bias: value }));
-    setActive(0);
-  }, []);
+  const updateSentimentFilter = useCallback(
+    (value) => {
+      setFilters((prev) => ({ ...prev, sentiment: value }));
+      resetToFirstCard();
+    },
+    [resetToFirstCard],
+  );
 
-  const handleSortChange = useCallback((event) => {
-    setSortBy(event.target.value);
-    setActive(0);
-  }, []);
+  const updateBiasFilter = useCallback(
+    (value) => {
+      setFilters((prev) => ({ ...prev, bias: value }));
+      resetToFirstCard();
+    },
+    [resetToFirstCard],
+  );
 
-  const handleSearchChange = useCallback((event) => {
-    setSearchTerm(event.target.value);
-  }, []);
+  const handleSortChange = useCallback(
+    (event) => {
+      setSortBy(event.target.value);
+      resetToFirstCard();
+    },
+    [resetToFirstCard],
+  );
+
+  const handleSearchChange = useCallback(
+    (event) => {
+      setSearchTerm(event.target.value);
+      resetToFirstCard();
+    },
+    [resetToFirstCard],
+  );
 
   return (
     <>
@@ -362,9 +464,9 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
           onSearchChange={handleSearchChange}
         />
 
-        {failures.length > 0 && (
+        {failureSources.length > 0 && (
           <div className="mb-3 text-xs text-amber-600">
-            Fuentes con incidencias: {failures.map((f) => f.name || f.source).join(', ')}.
+            Fuentes con incidencias temporales: {formatFailureSources(failureSources)}.
           </div>
         )}
 
@@ -404,7 +506,7 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
             <div className="pointer-events-none absolute inset-y-0 left-0 w-16 bg-gradient-to-r from-white to-transparent" />
             <div className="pointer-events-none absolute inset-y-0 right-0 w-16 bg-gradient-to-l from-white to-transparent" />
 
-            <div ref={wrapRef} className="news-scroll mt-4 flex gap-6 overflow-x-auto px-12 pb-10">
+            <div ref={wrapRef} className="news-scroll mt-4 flex snap-x snap-mandatory gap-6 overflow-x-auto px-12 pb-10">
               {cardsToRender.length === 0 && !isLoading && (
                 <div className="min-h-[220px] w-full rounded-2xl border border-gray-200 bg-gray-50/60 p-6 text-center text-sm text-gray-500">
                   Sin titulares recientes. Intenta recargar en unos minutos.
@@ -414,11 +516,6 @@ export default function GoldNewsGlassCarousel({ items, initialIndex = 0 }) {
               {cardsToRender.map((item, idx) => {
                 if (item.__skeleton) {
                   return <SkeletonCard key={item.id} />;
-                }
-
-                const shouldRender = virtualizationWindow.size ? virtualizationWindow.has(idx) : true;
-                if (!shouldRender) {
-                  return <VirtualPlaceholder key={item.id} />;
                 }
 
                 return (
@@ -581,7 +678,7 @@ function NewsCard({ item, index, isActive, onSelect }) {
       <div className="relative px-2">
         <div className="pointer-events-none absolute inset-x-8 -bottom-2 h-6 rounded-full bg-black/10 blur-lg transition group-hover:blur-xl" />
         <div className="relative overflow-hidden rounded-3xl ring-1 ring-black/5 shadow-[0_8px_24px_rgba(0,0,0,0.08)] transition-all duration-300 group-hover:shadow-[0_18px_36px_rgba(15,23,42,0.18)]">
-          <Thumb src={item.image} alt={item.title} idx={index} />
+          <Thumb src={item.image} alt={item.imageAlt || item.title} seed={item.image || item.id || item.link || `${index}`} />
           <div className="pointer-events-none absolute left-3 top-3 flex items-center gap-2">
             {item.sourceLogo && (
               <span className="flex h-8 w-8 items-center justify-center overflow-hidden rounded-full border border-white/60 bg-white/80 shadow-sm">
@@ -687,7 +784,7 @@ function InsightModal({ item, onClose }) {
 
         <div className="grid gap-6 md:grid-cols-[1.1fr_1fr]">
           <div className="relative">
-            <Thumb src={item.image} alt={item.title} idx={0} />
+            <Thumb src={item.image} alt={item.imageAlt || item.title} seed={item.image || item.id || item.link || item.title} />
             <div className="pointer-events-none absolute left-4 top-4 flex items-center gap-2">
               {item.sourceLogo && (
                 <span className="flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border border-white/60 bg-white/80 shadow">
@@ -813,8 +910,20 @@ function InsightSection({ icon: Icon, title, text }) {
   );
 }
 
-function VirtualPlaceholder() {
-  return <div className="min-w-[320px] max-w-[360px]" aria-hidden="true" />;
+function prettySourceLabel(name) {
+  const normalized = sanitizeText(name);
+  if (!normalized) return '';
+  const lookup = CANONICAL_SOURCE_LABELS[normalized.toLowerCase()];
+  if (lookup) return lookup;
+  return normalized;
+}
+
+function formatFailureSources(sources) {
+  if (!sources.length) return '';
+  if (sources.length <= 4) return sources.join(', ');
+  const visible = sources.slice(0, 4).join(', ');
+  const remaining = sources.length - 4;
+  return `${visible} y ${remaining} fuente${remaining === 1 ? '' : 's'} más`;
 }
 
 function SkeletonCard() {
@@ -864,20 +973,28 @@ function SkeletonCard() {
   );
 }
 
-function Thumb({ src, alt, idx = 0 }) {
+function Thumb({ src, alt, seed }) {
   const [okSrc, setOkSrc] = useState(null);
   const [loading, setLoading] = useState(true);
+  const fallbackStepRef = useRef(0);
+
+  useEffect(() => {
+    fallbackStepRef.current = 0;
+    setOkSrc(null);
+    setLoading(true);
+  }, [src, seed]);
 
   useEffect(() => {
     let alive = true;
-    const candidate = src || '';
+    const candidate = (src || '').trim();
     if (!candidate) {
-      setOkSrc(FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]);
+      setOkSrc(selectFallbackImage(seed, fallbackStepRef.current));
       setLoading(false);
       return () => {
         alive = false;
       };
     }
+
     const img = new Image();
     img.referrerPolicy = 'no-referrer';
     img.onload = () => {
@@ -888,33 +1005,55 @@ function Thumb({ src, alt, idx = 0 }) {
     };
     img.onerror = () => {
       if (alive) {
-        setOkSrc(FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]);
+        fallbackStepRef.current += 1;
+        setOkSrc(selectFallbackImage(seed, fallbackStepRef.current));
         setLoading(false);
       }
     };
     img.src = candidate;
+
     return () => {
       alive = false;
     };
-  }, [src, idx]);
+  }, [src, seed]);
+
+  const fallback = selectFallbackImage(seed, fallbackStepRef.current);
 
   return (
     <div className="relative aspect-[16/9] w-full bg-gray-100">
       {loading && <div className="absolute inset-0 animate-pulse bg-gray-200" />}
       <img
-        src={okSrc || FALLBACK_IMAGES[idx % FALLBACK_IMAGES.length]}
+        src={okSrc || fallback}
         alt={alt || 'thumbnail'}
         className="h-full w-full object-cover"
         loading="lazy"
         referrerPolicy="no-referrer"
         onLoad={() => setLoading(false)}
         onError={() => {
-          setOkSrc(FALLBACK_IMAGES[(idx + 1) % FALLBACK_IMAGES.length]);
+          fallbackStepRef.current += 1;
+          setOkSrc(selectFallbackImage(seed, fallbackStepRef.current));
           setLoading(false);
         }}
       />
     </div>
   );
+}
+
+function selectFallbackImage(seed, step = 0) {
+  const base = deterministicIndex(seed);
+  const offset = (base + step) % FALLBACK_IMAGES.length;
+  return FALLBACK_IMAGES[offset < 0 ? offset + FALLBACK_IMAGES.length : offset];
+}
+
+function deterministicIndex(seed) {
+  if (seed == null) return 0;
+  const str = String(seed);
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash) % FALLBACK_IMAGES.length;
 }
 
 function Badge({ tone = 'secondary', intensity = 1, children }) {
@@ -1123,17 +1262,18 @@ async function orchestrateEnrichment(rawItems, signal, imageCache) {
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       let sentimentLabel = 'neutral';
       let sentimentScore = 0.5;
+      let sentimentDistribution = null;
       try {
         const text = `${item.title || ''}. ${item.summaryHint || ''}`.trim();
         const predictions = await classifySentiment(text || item.title || '');
-        if (Array.isArray(predictions) && predictions[0]) {
-          sentimentLabel = mapSentimentLabel(predictions[0].label);
-          sentimentScore = predictions[0].score ?? sentimentScore;
-        }
+        const resolved = resolveSentiment(predictions);
+        sentimentLabel = resolved.label;
+        sentimentScore = resolved.score ?? sentimentScore;
+        sentimentDistribution = resolved.distribution ?? null;
       } catch (error) {
         console.warn('[GoldNews] FinBERT fallback', error);
       }
-      return { ...item, sentiment: sentimentLabel, sentimentScore };
+      return { ...item, sentiment: sentimentLabel, sentimentScore, sentimentDistribution };
     },
     signal,
   );
@@ -1300,14 +1440,6 @@ function normalizeBiasLabel(label) {
   return 'neutral';
 }
 
-function mapSentimentLabel(label) {
-  if (!label) return 'neutral';
-  const value = String(label).toLowerCase();
-  if (value.includes('positive') || value.includes('bull')) return 'bullish';
-  if (value.includes('negative') || value.includes('bear')) return 'bearish';
-  return 'neutral';
-}
-
 async function scoreWithMoE(items, signal) {
   if (!items.length) return [];
   if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
@@ -1361,26 +1493,119 @@ async function enrichImages(items, signal, cache) {
       if (signal?.aborted) throw new DOMException('Aborted', 'AbortError');
       const query = buildImageQuery(item);
       if (!query) return item;
-      const cached = cache.get(query);
+
       const now = Date.now();
-      if (cached && cached.expiresAt > now) {
-        return { ...item, image: cached.url || item.image, imageAttribution: cached.credit || item.imageAttribution || null };
+      let cached = cache.get(query);
+      if (cached && cached.expiresAt <= now) {
+        cache.delete(query);
+        cached = null;
       }
+
+      if (cached && !Array.isArray(cached.results) && cached.url) {
+        return mergeImageSelection(item, { url: cached.url, credit: cached.credit || null, alt: cached.alt || '' });
+      }
+
+      if (cached && !Array.isArray(cached.results)) {
+        cache.delete(query);
+        cached = null;
+      }
+
+      if (cached?.results?.length) {
+        const selection = pickImageFromCache(query, cached, item);
+        if (selection) {
+          return mergeImageSelection(item, selection);
+        }
+      }
+
       try {
         const response = await fetchWithBackoff(`/api/images?q=${encodeURIComponent(query)}`, { signal, attempts: 1, baseDelay: 400 });
-        const best = Array.isArray(response?.items) ? response.items[0] : null;
-        if (best?.url) {
-          cache.set(query, { url: best.url, credit: best.credit || null, expiresAt: now + CACHE_TTL_MS / 2 });
-          return { ...item, image: best.url, imageAttribution: best.credit || null };
+        const results = Array.isArray(response?.items)
+          ? response.items.filter((entry) => entry?.url)
+          : [];
+        if (results.length) {
+          const entry = {
+            results: results.map((entry) => ({
+              url: entry.url,
+              credit: entry.credit || null,
+              alt: entry.alt || '',
+            })),
+            expiresAt: now + CACHE_TTL_MS / 2,
+            assignments: new Map(),
+          };
+          cache.set(query, entry);
+          const selection = pickImageFromCache(query, entry, item);
+          if (selection) {
+            return mergeImageSelection(item, selection);
+          }
         }
       } catch (error) {
         console.warn('[GoldNews] Unsplash fallback', error);
+        if (!cached) {
+          cache.set(query, { results: [], assignments: new Map(), expiresAt: now + 60_000 });
+        }
       }
-      cache.set(query, { url: item.image, credit: item.imageAttribution || null, expiresAt: now + 60_000 });
+
+      if (cached?.results?.length) {
+        const selection = pickImageFromCache(query, cached, item);
+        if (selection) {
+          return mergeImageSelection(item, selection);
+        }
+      }
+
       return item;
     },
     signal,
   );
+}
+
+function pickImageFromCache(query, entry, item) {
+  if (!entry || !Array.isArray(entry.results) || entry.results.length === 0) return null;
+  if (!(entry.assignments instanceof Map)) {
+    entry.assignments = new Map();
+  }
+  const key = buildImageAssignmentKey(item);
+  if (entry.assignments.has(key)) {
+    const assigned = entry.assignments.get(key);
+    return entry.results[assigned] || null;
+  }
+  const total = entry.results.length;
+  const used = new Set(entry.assignments.values());
+  let index = hashToIndex(`${query}:${key}`, total);
+  for (let step = 0; step < total; step += 1) {
+    const candidate = (index + step) % total;
+    if (!used.has(candidate) && entry.results[candidate]) {
+      entry.assignments.set(key, candidate);
+      return entry.results[candidate];
+    }
+  }
+  const fallbackIndex = hashToIndex(`${query}:${key}:fallback`, total);
+  entry.assignments.set(key, fallbackIndex);
+  return entry.results[fallbackIndex] || entry.results[0] || null;
+}
+
+function mergeImageSelection(item, selection) {
+  if (!selection) return item;
+  return {
+    ...item,
+    image: selection.url || item.image,
+    imageAlt: selection.alt || item.imageAlt || item.title || null,
+    imageAttribution: selection.credit || item.imageAttribution || null,
+  };
+}
+
+function buildImageAssignmentKey(item) {
+  return item?.id || item?.dedupKey || stableHash(`${item?.title || ''}${item?.link || ''}`);
+}
+
+function hashToIndex(seed, length) {
+  if (!length) return 0;
+  const str = String(seed || '');
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = (hash << 5) - hash + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash) % length;
 }
 
 function buildImageQuery(item) {

--- a/src/utils/unsplash.js
+++ b/src/utils/unsplash.js
@@ -20,6 +20,9 @@ export async function searchUnsplashImages(query = 'gold bullion', perPage = 3) 
   const params = new URLSearchParams({
     query,
     per_page: String(perPage),
+    order_by: 'relevant',
+    orientation: 'landscape',
+    content_filter: 'high',
     client_id: accessKey
   });
   const url = `${UNSPLASH_ENDPOINT}?${params.toString()}`;


### PR DESCRIPTION
## Summary
- interpret FinBERT probability distributions to surface bullish/bearish leanings with confidence data instead of defaulting to neutral sentiment tags
- request richer Unsplash batches server-side and deterministically assign distinct images per article while propagating alt text to the cards and modal
- reuse the enhanced sentiment resolver across batch classification utilities for consistent labeling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d580b9af50832da560d0cb50d08ac0